### PR TITLE
[EMR-WEB-006] - Barra de Acciones Rápidas — Web Component reutilizable por módulo

### DIFF
--- a/src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.css
+++ b/src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.css
@@ -57,6 +57,7 @@
     opacity: 0;
     transform: translateY(-5px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -71,14 +72,25 @@
   justify-content: flex-start;
   padding: var(--space-2) var(--space-4);
   border-radius: 0;
-  color: var(--color-text-primary);
-  min-height: 44px; /* Móvil tap target */
-  transition: background-color var(--transition-fast), color var(--transition-fast);
+  color: var(--color-text-secondary);
+  min-height: 44px;
+  /* Móvil tap target */
+  transition: all var(--transition-fast);
+}
+
+.qab-action-btn svg {
+  color: var(--color-icon);
+  transition: color var(--transition-fast);
 }
 
 .qab-action-btn:hover:not(.disabled) {
-  background-color: var(--color-bg-secondary);
-  color: var(--color-primary);
+  background-color: transparent;
+  color: var(--color-text);
+  transform: translateX(4px); /* Adding a slight animation commonly associated with vertical sub-menus */
+}
+
+.qab-action-btn:hover:not(.disabled) svg {
+  color: var(--color-text);
 }
 
 .qab-action-btn.disabled {
@@ -96,23 +108,27 @@
 /* Responsividad */
 @media (max-width: 768px) {
   .qab-module-label {
-    display: none; /* Ocultar el texto en móvil */
+    display: none;
+    /* Ocultar el texto en móvil */
   }
 
   .quick-action-bar-btn {
     padding: var(--space-2);
-    min-height: 44px; /* Móvil tap target */
+    min-height: 44px;
+    /* Móvil tap target */
     min-width: 44px;
     justify-content: center;
   }
 
   .qab-chevron {
-    display: none; /* Ocular el chevron en móvil, solo mantener el ícono del módulo */
+    display: none;
+    /* Ocular el chevron en móvil, solo mantener el ícono del módulo */
   }
-  
+
   .qab-dropdown {
     /* Ajustar dropdown en pantallas pequeñas para no salir del viewport */
     min-width: 180px;
-    left: auto; /* Remover left: 0 */
+    left: auto;
+    /* Remover left: 0 */
   }
 }

--- a/src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.css
+++ b/src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.css
@@ -1,0 +1,118 @@
+/* QuickActionBar.css */
+
+.quick-action-bar-container {
+  position: relative;
+  display: inline-block;
+}
+
+.quick-action-bar-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: all var(--transition-normal);
+}
+
+.quick-action-bar-btn.open {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-primary);
+}
+
+.quick-action-bar-btn.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: grayscale(100%);
+}
+
+.qab-chevron {
+  display: flex;
+  margin-left: var(--space-1);
+  transition: transform 0.2s ease-in-out;
+}
+
+.qab-chevron.open {
+  transform: rotate(180deg);
+}
+
+.qab-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: var(--space-1);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  min-width: 200px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-1) 0;
+  animation: dropdownFadeIn 0.2s ease-out;
+}
+
+@keyframes dropdownFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.qab-action-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  justify-content: flex-start;
+  padding: var(--space-2) var(--space-4);
+  border-radius: 0;
+  color: var(--color-text-primary);
+  min-height: 44px; /* Móvil tap target */
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.qab-action-btn:hover:not(.disabled) {
+  background-color: var(--color-bg-secondary);
+  color: var(--color-primary);
+}
+
+.qab-action-btn.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.qab-empty-state {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+/* Responsividad */
+@media (max-width: 768px) {
+  .qab-module-label {
+    display: none; /* Ocultar el texto en móvil */
+  }
+
+  .quick-action-bar-btn {
+    padding: var(--space-2);
+    min-height: 44px; /* Móvil tap target */
+    min-width: 44px;
+    justify-content: center;
+  }
+
+  .qab-chevron {
+    display: none; /* Ocular el chevron en móvil, solo mantener el ícono del módulo */
+  }
+  
+  .qab-dropdown {
+    /* Ajustar dropdown en pantallas pequeñas para no salir del viewport */
+    min-width: 180px;
+    left: auto; /* Remover left: 0 */
+  }
+}

--- a/src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.tsx
+++ b/src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.tsx
@@ -1,0 +1,99 @@
+import { useState, useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
+import "@/presentation/modules/shared/components/QuickActionBar/QuickActionBar.css";
+
+export interface QuickAction {
+  label: string;
+  icon: string;
+  route?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+export interface QuickActionBarProps {
+  module: string;
+  icon: string;
+  actions: QuickAction[];
+  disabled?: boolean;
+}
+
+export function QuickActionBar({
+  module,
+  icon,
+  actions,
+  disabled = false,
+}: QuickActionBarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const handleToggle = () => {
+    if (disabled) return;
+    setIsOpen(!isOpen);
+  };
+
+  const handleActionClick = (action: QuickAction) => {
+    if (action.disabled) return;
+    
+    setIsOpen(false);
+    if (action.route) {
+      navigate(action.route);
+    } else if (action.onClick) {
+      action.onClick();
+    }
+  };
+
+  return (
+    <div className="quick-action-bar-container" ref={menuRef}>
+      <button
+        type="button"
+        className={`btn-ghost quick-action-bar-btn ${isOpen ? "open" : ""} ${disabled ? "disabled" : ""}`}
+        onClick={handleToggle}
+        disabled={disabled}
+        title={disabled ? "Módulo Pendiente" : ""}
+      >
+        <Icon name={icon} size={16} />
+        <span className="qab-module-label">{module}</span>
+        <div className={`qab-chevron ${isOpen ? "open" : ""}`}>
+          <Icon name="icon-chevron-down" size={14} />
+        </div>
+      </button>
+
+      {isOpen && !disabled && (
+        <div className="qab-dropdown">
+          {actions.map((action, idx) => (
+            <button
+              key={`${action.label}-${idx}`}
+              type="button"
+              className={`btn-ghost qab-action-btn ${action.disabled ? "disabled" : ""}`}
+              onClick={() => handleActionClick(action)}
+              disabled={action.disabled}
+              title={action.disabled ? "Acción no disponible" : ""}
+            >
+              <Icon name={action.icon} size={16} />
+              <span className="qab-action-label">{action.label}</span>
+            </button>
+          ))}
+          {actions.length === 0 && (
+            <div className="qab-empty-state">
+              Sin acciones disponibles
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/presentation/modules/shared/components/QuickActionBar/README.md
+++ b/src/presentation/modules/shared/components/QuickActionBar/README.md
@@ -1,0 +1,78 @@
+# QuickActionBar Component
+
+Este es un componente reutilizable para mostrar un menú desplegable de "Acciones Rápidas" asociado a un módulo del sistema EMR.
+
+## Instalación & Importación
+
+```tsx
+import { QuickActionBar } from "@/presentation/modules/shared/components/QuickActionBar";
+```
+
+## Props / Configuración
+
+El componente `QuickActionBar` acepta la siguiente configuración:
+
+- `module` (string): Nombre del módulo (ej. "Pacientes"). Se oculta automáticamente en pantallas pequeñas.
+- `icon` (string): Nombre del ícono de la librería preexistente `Icon` (ej. "icon-users").
+- `actions` (Array<QuickAction>): Lista de acciones a desplegar. Las acciones pueden ser rutas de navegación o funciones ejecutables.
+- `disabled` (boolean) [Opcional]: Deshabilita el componente completo mostrando estado de módulo pendiente/no implementado.
+
+### `QuickAction` Interface
+
+```ts
+export interface QuickAction {
+  label: string;
+  icon: string;
+  route?: string;                // Si se provee, navegará a la ruta al clicar
+  onClick?: () => void;          // Si se provee, ejecutará la función
+  disabled?: boolean;            // Deshabilita la acción específica
+}
+```
+
+## Ejemplo de uso e integración
+
+### Módulo Funcional (Pacientes)
+
+```tsx
+<QuickActionBar
+  module="Pacientes"
+  icon="icon-users"
+  actions={[
+    { 
+      label: 'Buscar Paciente', 
+      icon: 'icon-search', 
+      onClick: () => setQuickSearchModalOpen(true) 
+    },
+    { 
+      label: 'Registrar Nuevo', 
+      icon: 'icon-user-plus', 
+      onClick: () => setCreateModalOpen(true) 
+    }
+  ]}
+/>
+```
+
+### Módulo Pendiente de Implementar
+
+Puedes deshabilitar el botón principal pasando `disabled={true}`, y opcionalmente un arreglo vacío para `actions`. Visualmente, el botón indicará que no está disponible (`not-allowed`, `grayscale`).
+
+```tsx
+<QuickActionBar
+  module="Historias Clínicas"
+  icon="icon-file-text" // Usar icono relacionado
+  actions={[]}
+  disabled={true}
+/>
+```
+
+### Rutas (React Router)
+
+```tsx
+<QuickActionBar
+  module="Reportes"
+  icon="icon-bar-chart"
+  actions={[
+    { label: 'Ver General', icon: 'icon-eye', route: '/reportes/general' },
+  ]}
+/>
+```

--- a/src/presentation/modules/shared/components/QuickActionBar/index.ts
+++ b/src/presentation/modules/shared/components/QuickActionBar/index.ts
@@ -1,0 +1,2 @@
+export { QuickActionBar } from "@/presentation/modules/shared/components/QuickActionBar/QuickActionBar";
+export type { QuickAction, QuickActionBarProps } from "@/presentation/modules/shared/components/QuickActionBar/QuickActionBar";

--- a/src/presentation/modules/shared/layouts/AppLayout.tsx
+++ b/src/presentation/modules/shared/layouts/AppLayout.tsx
@@ -1,6 +1,8 @@
 import { useAuth } from "@/presentation/modules/auth/hooks/useAuth";
 import { usePresenceTracker } from "@/presentation/modules/users/hooks/usePresenceTracker";
-import { useState, useRef, useEffect } from "react";
+import { useUserStore } from "@/presentation/modules/users/stores/useUserStore";
+import { useAdminUsers } from "@/presentation/modules/users/hooks/useAdminUsers";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ThemeToggle } from "@/presentation/modules/shared/components/ThemeToggle";
 import { UserProfileModal } from "@/presentation/modules/users/components/UserProfileModal";
@@ -14,13 +16,17 @@ import { usePatientStore } from "@/presentation/modules/patient/stores/usePatien
 import { PatientCreateModal } from "@/presentation/modules/patient/components/Patients/PatientCreateModal";
 import { PatientQuickSearchModal } from "@/presentation/modules/patient/components/Patients/PatientQuickSearchModal";
 import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
+import { QuickActionBar } from "@/presentation/modules/shared/components/QuickActionBar";
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const { user, logout, isLoggingOut } = useAuth();
   const navigate = useNavigate();
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
-  const [isPatientMenuOpen, setIsPatientMenuOpen] = useState(false);
-  const patientMenuRef = useRef<HTMLDivElement>(null);
+
+  const { setInviteModalOpen } = useUserStore();
+  // Safe to use here because it's a hook wrapping react-query; calling loadUsers will fetch data 
+  // and populate cache, making the management page automatically activate upon navigation.
+  const { loadUsers } = useAdminUsers();
 
   const {
     isCreateModalOpen,
@@ -34,16 +40,6 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   usePresenceTracker(user?.id);
   useNotificationSubscription(user?.id);
   usePatientSubscription();
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (patientMenuRef.current && !patientMenuRef.current.contains(event.target as Node)) {
-        setIsPatientMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
 
   const handleLogout = async () => {
     await logout();
@@ -148,95 +144,75 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         <div
           style={{
             display: "flex",
+            flexWrap: "wrap",
             alignItems: "center",
             padding: "var(--space-2) var(--space-6)",
             backgroundColor: "var(--color-bg-secondary)",
             borderBottom: "1px solid var(--color-border)",
-            gap: "var(--space-4)",
+            gap: "var(--space-2)",
           }}
+          title="Acciones Rápidas"
         >
-          <div style={{ position: "relative" }} ref={patientMenuRef}>
-            <button
-              type="button"
-              className="btn-ghost"
-              onClick={() => setIsPatientMenuOpen(!isPatientMenuOpen)}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-2)",
-                fontSize: "var(--font-size-sm)",
-                fontWeight: "var(--font-weight-medium)",
-              }}
-            >
-              <Icon name="icon-users" size={16} />
-              Pacientes
-              <div style={{ marginLeft: "var(--space-1)", display: "flex" }}>
-                <Icon name="icon-chevron-down" size={14} />
-              </div>
-            </button>
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-2)",
+            color: "var(--color-text-secondary)",
+            fontSize: "var(--font-size-sm)",
+            fontWeight: "var(--font-weight-medium)",
+            whiteSpace: "nowrap",
+            marginRight: "var(--space-4)"
+          }}>
+            <Icon name="icon-dashboard" size={16} />
+            <span style={{ display: "inline-block" }} className="quick-actions-title">Acciones Rápidas:</span>
+          </div>
 
-            {isPatientMenuOpen && (
-              <div
-                style={{
-                  position: "absolute",
-                  top: "100%",
-                  left: 0,
-                  marginTop: "var(--space-1)",
-                  backgroundColor: "var(--color-surface)",
-                  border: "1px solid var(--color-border)",
-                  borderRadius: "var(--radius-md)",
-                  boxShadow: "var(--shadow-md)",
-                  minWidth: "200px",
-                  zIndex: 50,
-                  display: "flex",
-                  flexDirection: "column",
-                  padding: "var(--space-1) 0",
-                }}
-              >
-                <button
-                  type="button"
-                  className="btn-ghost"
-                  onClick={() => {
-                    setQuickSearchModalOpen(true);
-                    setIsPatientMenuOpen(false);
-                  }}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "var(--space-2)",
-                    width: "100%",
-                    justifyContent: "flex-start",
-                    padding: "var(--space-2) var(--space-4)",
-                    borderRadius: 0,
-                    color: "var(--color-text-primary)",
-                  }}
-                >
-                  <Icon name="icon-search" size={16} />
-                  Buscar Paciente
-                </button>
-                <button
-                  type="button"
-                  className="btn-ghost"
-                  onClick={() => {
-                    setCreateModalOpen(true);
-                    setIsPatientMenuOpen(false);
-                  }}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "var(--space-2)",
-                    width: "100%",
-                    justifyContent: "flex-start",
-                    padding: "var(--space-2) var(--space-4)",
-                    borderRadius: 0,
-                    color: "var(--color-text-primary)",
-                  }}
-                >
-                  <Icon name="icon-user-plus" size={16} />
-                  Registrar Nuevo
-                </button>
-              </div>
-            )}
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+            <QuickActionBar
+              module="Pacientes"
+              icon="icon-users"
+              actions={[
+                { label: 'Buscar Paciente', icon: 'icon-search', onClick: () => setQuickSearchModalOpen(true) },
+                { label: 'Registrar Nuevo', icon: 'icon-user-plus', onClick: () => setCreateModalOpen(true) }
+              ]}
+            />
+            
+            <QuickActionBar
+              module="Usuarios"
+              icon="icon-user"
+              actions={[
+                { 
+                  label: 'Cargar usuarios', 
+                  icon: 'icon-users', 
+                  onClick: () => {
+                    loadUsers();
+                    navigate("/admin/users");
+                  } 
+                },
+                { 
+                  label: 'Invitar Usuario', 
+                  icon: 'icon-user-plus', 
+                  onClick: () => {
+                    setInviteModalOpen(true);
+                    navigate("/admin/users");
+                  } 
+                }
+              ]}
+            />
+
+            <QuickActionBar
+              module="Historias Clínicas"
+              icon="icon-clinical-history"
+              actions={[]}
+              disabled={true}
+            />
+
+            <QuickActionBar
+              module="Evoluciones Médicas"
+              icon="icon-medical-evolution"
+              actions={[]}
+              disabled={true}
+            />
           </div>
         </div>
 

--- a/src/presentation/modules/shared/layouts/AppLayout.tsx
+++ b/src/presentation/modules/shared/layouts/AppLayout.tsx
@@ -2,6 +2,7 @@ import { useAuth } from "@/presentation/modules/auth/hooks/useAuth";
 import { usePresenceTracker } from "@/presentation/modules/users/hooks/usePresenceTracker";
 import { useUserStore } from "@/presentation/modules/users/stores/useUserStore";
 import { useAdminUsers } from "@/presentation/modules/users/hooks/useAdminUsers";
+import { InviteUserModal } from "@/presentation/modules/users/components/InviteUserModal";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ThemeToggle } from "@/presentation/modules/shared/components/ThemeToggle";
@@ -15,7 +16,6 @@ import { usePatientSubscription } from "@/presentation/modules/patient/hooks/use
 import { usePatientStore } from "@/presentation/modules/patient/stores/usePatientStore";
 import { PatientCreateModal } from "@/presentation/modules/patient/components/Patients/PatientCreateModal";
 import { PatientQuickSearchModal } from "@/presentation/modules/patient/components/Patients/PatientQuickSearchModal";
-import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
 import { QuickActionBar } from "@/presentation/modules/shared/components/QuickActionBar";
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
@@ -23,10 +23,10 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
 
-  const { setInviteModalOpen } = useUserStore();
+  const { setInviteModalOpen, isInviteModalOpen } = useUserStore();
   // Safe to use here because it's a hook wrapping react-query; calling loadUsers will fetch data 
   // and populate cache, making the management page automatically activate upon navigation.
-  const { loadUsers } = useAdminUsers();
+  const { loadUsers, inviteUser, isInviting, isActivated: isUsersLoaded } = useAdminUsers();
 
   const {
     isCreateModalOpen,
@@ -163,14 +163,13 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             whiteSpace: "nowrap",
             marginRight: "var(--space-4)"
           }}>
-            <Icon name="icon-dashboard" size={16} />
             <span style={{ display: "inline-block" }} className="quick-actions-title">Acciones Rápidas:</span>
           </div>
 
           <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
             <QuickActionBar
               module="Pacientes"
-              icon="icon-users"
+              icon="icon-patient"
               actions={[
                 { label: 'Buscar Paciente', icon: 'icon-search', onClick: () => setQuickSearchModalOpen(true) },
                 { label: 'Registrar Nuevo', icon: 'icon-user-plus', onClick: () => setCreateModalOpen(true) }
@@ -179,7 +178,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             
             <QuickActionBar
               module="Usuarios"
-              icon="icon-user"
+              icon="icon-users"
               actions={[
                 { 
                   label: 'Cargar usuarios', 
@@ -194,7 +193,6 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   icon: 'icon-user-plus', 
                   onClick: () => {
                     setInviteModalOpen(true);
-                    navigate("/admin/users");
                   } 
                 }
               ]}
@@ -239,6 +237,17 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
       <PatientQuickSearchModal 
         isOpen={isQuickSearchModalOpen}
         onClose={() => setQuickSearchModalOpen(false)}
+      />
+
+      <InviteUserModal
+        isOpen={isInviteModalOpen}
+        onClose={() => setInviteModalOpen(false)}
+        onInvite={async (payload) => {
+          await inviteUser(payload);
+          // If the table was never loaded but we invite, we load it so if they navigate it's there
+          if (!isUsersLoaded) loadUsers();
+        }}
+        isInviting={isInviting}
       />
     </div>
   );

--- a/src/presentation/modules/users/hooks/useAdminUsers.ts
+++ b/src/presentation/modules/users/hooks/useAdminUsers.ts
@@ -1,10 +1,11 @@
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SupabaseUserRepository } from "@/infrastructure/modules/users/repositories/SupabaseUserRepository";
 import { InviteUser } from "@/application/modules/users/use-cases/inviteUser";
 import { ToggleUserStatus } from "@/application/modules/users/use-cases/toggleUserStatus";
 import { SoftDeleteUser } from "@/application/modules/users/use-cases/softDeleteUser";
 import type { AccountStatus, InviteUserPayload } from "@/domain/modules/users/models/User";
+import { useUserStore } from "@/presentation/modules/users/stores/useUserStore";
 
 const userRepository = new SupabaseUserRepository();
 const inviteUseCase = new InviteUser(userRepository);
@@ -18,9 +19,8 @@ const TEN_MINUTES = 1000 * 60 * 10;
 
 export function useAdminUsers() {
   const queryClient = useQueryClient();
-  const [isActivated, setIsActivated] = useState(() => {
-    return !!queryClient.getQueryData(ADMIN_USERS_QUERY_KEY);
-  });
+  const isActivated = useUserStore((state) => state.isUsersLoaded);
+  const setIsActivated = useUserStore((state) => state.setUsersLoaded);
 
   const {
     data: users,

--- a/src/presentation/modules/users/pages/UsersManagementPage.tsx
+++ b/src/presentation/modules/users/pages/UsersManagementPage.tsx
@@ -7,7 +7,6 @@ import type {
   UserWithPresence,
 } from "@/domain/modules/users/models/User";
 import { USER_ROLE_LABELS, ACCOUNT_STATUS_LABELS } from "@/domain/modules/users/models/User";
-import { InviteUserModal } from "@/presentation/modules/users/components/InviteUserModal";
 import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
 import { useUserStore } from "@/presentation/modules/users/stores/useUserStore";
 import "@/presentation/modules/shared/components/ui/webcomponents/wcButton";
@@ -21,8 +20,6 @@ export function UsersManagementPage() {
     isLoading,
     isActivated,
     loadUsers,
-    inviteUser,
-    isInviting,
     toggleUserStatus,
     isTogglingStatus,
     softDeleteUser,
@@ -31,7 +28,7 @@ export function UsersManagementPage() {
 
   const { addToast } = useToastStore();
 
-  const { isInviteModalOpen, setInviteModalOpen } = useUserStore();
+  const { setInviteModalOpen } = useUserStore();
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
 
@@ -75,16 +72,6 @@ export function UsersManagementPage() {
             Invitar Usuario
           </button>
         </div>
-
-        <InviteUserModal
-          isOpen={isInviteModalOpen}
-          onClose={() => setInviteModalOpen(false)}
-          onInvite={async (payload) => {
-            await inviteUser(payload)
-            if (!isActivated) loadUsers();
-          }}
-          isInviting={isInviting}
-        />
 
         <div
           className="card"
@@ -175,15 +162,6 @@ export function UsersManagementPage() {
           Invitar Usuario
         </button>
       </div>
-
-      <InviteUserModal
-        isOpen={isInviteModalOpen}
-        onClose={() => setInviteModalOpen(false)}
-        onInvite={async (payload) => {
-          await inviteUser(payload)
-        }}
-        isInviting={isInviting}
-      />
 
        <wc-tabs>
         <wc-button variant="tab" slot="tab">

--- a/src/presentation/modules/users/pages/UsersManagementPage.tsx
+++ b/src/presentation/modules/users/pages/UsersManagementPage.tsx
@@ -9,6 +9,7 @@ import type {
 import { USER_ROLE_LABELS, ACCOUNT_STATUS_LABELS } from "@/domain/modules/users/models/User";
 import { InviteUserModal } from "@/presentation/modules/users/components/InviteUserModal";
 import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
+import { useUserStore } from "@/presentation/modules/users/stores/useUserStore";
 import "@/presentation/modules/shared/components/ui/webcomponents/wcButton";
 import "@/presentation/modules/shared/components/ui/webcomponents/wcTabs";
 
@@ -30,7 +31,7 @@ export function UsersManagementPage() {
 
   const { addToast } = useToastStore();
 
-  const [showInviteForm, setShowInviteForm] = useState(false);
+  const { isInviteModalOpen, setInviteModalOpen } = useUserStore();
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
 
@@ -67,7 +68,7 @@ export function UsersManagementPage() {
           <button
             type="button"
             className="btn-primary"
-            onClick={() => setShowInviteForm(true)}
+            onClick={() => setInviteModalOpen(true)}
             style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}
           >
             <Icon name="icon-user-plus" size={20} />
@@ -76,8 +77,8 @@ export function UsersManagementPage() {
         </div>
 
         <InviteUserModal
-          isOpen={showInviteForm}
-          onClose={() => setShowInviteForm(false)}
+          isOpen={isInviteModalOpen}
+          onClose={() => setInviteModalOpen(false)}
           onInvite={async (payload) => {
             await inviteUser(payload)
             if (!isActivated) loadUsers();
@@ -167,7 +168,7 @@ export function UsersManagementPage() {
         <button
           type="button"
           className="btn-primary"
-          onClick={() => setShowInviteForm(true)}
+          onClick={() => setInviteModalOpen(true)}
           style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}
         >
           <Icon name="icon-user-plus" size={20} />
@@ -176,8 +177,8 @@ export function UsersManagementPage() {
       </div>
 
       <InviteUserModal
-        isOpen={showInviteForm}
-        onClose={() => setShowInviteForm(false)}
+        isOpen={isInviteModalOpen}
+        onClose={() => setInviteModalOpen(false)}
         onInvite={async (payload) => {
           await inviteUser(payload)
         }}

--- a/src/presentation/modules/users/stores/useUserStore.ts
+++ b/src/presentation/modules/users/stores/useUserStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface UserStore {
+  isInviteModalOpen: boolean;
+  setInviteModalOpen: (isOpen: boolean) => void;
+  isUsersLoaded: boolean;
+  setUsersLoaded: (isLoaded: boolean) => void;
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  isInviteModalOpen: false,
+  setInviteModalOpen: (isOpen) => set({ isInviteModalOpen: isOpen }),
+  isUsersLoaded: false,
+  setUsersLoaded: (isLoaded) => set({ isUsersLoaded: isLoaded }),
+}));


### PR DESCRIPTION

Implementar un componente genérico y reutilizable `<QuickActionBar />` para reemplazar el menú de acciones rápidas de "Pacientes" (previamente *hardcoded*) en el `AppLayout`. Esta actualización mejora la UX con animaciones y estados visuales claros, añade diseño responsivo para móviles, y soporta navegación por rutas o *callbacks*. Además, se integran 3 menús de acciones rápidas adicionales.

## 🛠️ Cambios Realizados

### Componentes Compartidos (Nuevos)
* **`src/presentation/modules/shared/components/QuickActionBar/QuickActionBar.tsx`**: Componente principal. Recibe `module`, `icon` y un arreglo de `actions`. Maneja el diseño responsivo (oculta texto en móvil), animación del *dropdown*, estados deshabilitados y la ejecución de rutas (`react-router`) o *callbacks*.
* **`src/presentation/modules/shared/components/QuickActionBar/index.ts`**: Archivo de barril para exportar el componente y sus interfaces/tipos.
* **`src/presentation/modules/shared/components/QuickActionBar/README.md`**: Documentación técnica del componente, *props* y ejemplos de uso.

### Layout (Modificado)
* **`src/presentation/modules/shared/layouts/AppLayout.tsx`**:
  * Se añadió la etiqueta "Acciones Rápidas:" al subencabezado.
  * Reemplazo del antiguo menú de "Pacientes" por la nueva instancia de `<QuickActionBar />`.
  * Integración del menú de "Usuarios" con sus acciones correspondientes.
  * Integración de los menús de "Historias Clínicas" y "Evoluciones Médicas" configurados en estado `disabled`.
  * Se aplicaron estilos para permitir *flex-wrap* o *scroll* horizontal en el subencabezado en caso de múltiples módulos.
## Imagenes
<img width="1093" height="205" alt="image" src="https://github.com/user-attachments/assets/59f771bb-ccb7-46b6-8c7b-0dfed741e4b0" />
<img width="1002" height="118" alt="image" src="https://github.com/user-attachments/assets/3ea3f8ec-3da3-4fc6-8283-b117d49694aa" />
<img width="986" height="76" alt="image" src="https://github.com/user-attachments/assets/4d38b16e-bb95-4f9c-8ce0-d7ec429baf30" />
<img width="345" height="188" alt="image" src="https://github.com/user-attachments/assets/524bacaf-5427-42b2-b847-38fb6aa264d4" />
<img width="436" height="189" alt="image" src="https://github.com/user-attachments/assets/df62f04a-77ec-47f3-b57b-cbe032d2843d" />
<img width="469" height="952" alt="image" src="https://github.com/user-attachments/assets/13392122-60ac-4b40-9766-d5caa66cfe1b" />

Closes #10 

