### PR TITLE
feat: Implementar traducción de errores enviados por supaBase en la s…

### DIFF
--- a/src/infrastructure/modules/auth/errors/authErrorMessages.ts
+++ b/src/infrastructure/modules/auth/errors/authErrorMessages.ts
@@ -1,0 +1,37 @@
+export const AUTH_DEFAULT_ERROR_MESSAGE_ES =
+  "No se pudo iniciar sesión. Intenta nuevamente.";
+
+export const AUTH_ERROR_MESSAGES_ES = {
+  bad_json: "Datos inválidos. Intenta de nuevo.",
+  invalid_credentials: "Credenciales incorrectas.",
+  email_not_confirmed: "Correo no confirmado.",
+  phone_not_confirmed: "Teléfono no confirmado.",
+  user_banned: "Tu cuenta está bloqueada.",
+  email_provider_disabled: "Login por correo no disponible.",
+  phone_provider_disabled: "Login por teléfono no disponible.",
+  provider_disabled: "Método de acceso no disponible.",
+  validation_failed: "Datos de acceso inválidos.",
+  over_request_rate_limit: "Demasiados intentos. Intenta más tarde.",
+  captcha_failed: "No se pudo validar la seguridad.",
+  request_timeout: "La solicitud tardó demasiado.",
+  unexpected_failure: "Ocurrió un error interno.",
+};
+
+function cleanErrorCode(code?: string | null): string {
+  if (!code) {
+    return "";
+  }
+  return code.trim().toLowerCase();
+}
+
+export function translateAuthErrorCode(code?: string | null): string {
+  const normalizedCode = cleanErrorCode(code);
+  if (!normalizedCode) {
+    return AUTH_DEFAULT_ERROR_MESSAGE_ES;
+  }
+
+  return (
+    AUTH_ERROR_MESSAGES_ES[normalizedCode as keyof typeof AUTH_ERROR_MESSAGES_ES] ??
+    AUTH_DEFAULT_ERROR_MESSAGE_ES
+  );
+}

--- a/src/infrastructure/modules/auth/repositories/SupabaseAuthRepository.ts
+++ b/src/infrastructure/modules/auth/repositories/SupabaseAuthRepository.ts
@@ -1,6 +1,7 @@
 import type { AuthRepository } from "@/domain/modules/auth/repositories/AuthRepository";
 import type { UserProfile } from "@/domain/modules/users/models/User";
 import { supabase } from "@/infrastructure/core/supabaseClient";
+import { translateAuthErrorCode } from "@/infrastructure/modules/auth/errors/authErrorMessages";
 import { mapProfileRow } from "@/infrastructure/modules/users/mappers/profileMapper";
 import type { ProfileRow } from "@/infrastructure/modules/users/mappers/profileMapper";
 
@@ -12,7 +13,7 @@ export class SupabaseAuthRepository implements AuthRepository {
     });
 
     if (error) {
-      throw new Error(error.message);
+      throw new Error(translateAuthErrorCode(error.code));
     }
 
     if (!data.user) {

--- a/src/presentation/modules/auth/pages/LoginPage.tsx
+++ b/src/presentation/modules/auth/pages/LoginPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/presentation/modules/auth/schemas/auth.schema'
 
 export function LoginPage() {
-  const { login, isLoggingIn, isAuthenticated, isLoading } = useAuth()
+  const { login, isLoggingIn, isAuthenticated, isLoading, loginError } = useAuth()
   const navigate = useNavigate()
 
   const [isRecovering, setIsRecovering] = useState(false)
@@ -49,6 +49,8 @@ export function LoginPage() {
   if (isAuthenticated && !isLoading) {
     return <Navigate to="/" replace />
   }
+  
+  const loginErrorMessage = loginError instanceof Error ? loginError.message : null
 
   const onLogin = async (data: LoginFormData) => {
     try {
@@ -286,6 +288,22 @@ export function LoginPage() {
         {!isRecovering ? (
           /* Login Form */
           <form onSubmit={handleLoginSubmit(onLogin)} noValidate>
+          {loginErrorMessage && (
+            <div
+              style={{
+                padding: 'var(--space-3)',
+                marginBottom: 'var(--space-4)',
+                borderRadius: 'var(--radius-md)',
+                backgroundColor: 'var(--color-danger-light)',
+                color: 'var(--color-danger)',
+                fontSize: 'var(--font-size-sm)',
+                fontWeight: 'var(--font-weight-medium)',
+                border: '1px solid var(--color-danger)',
+              }}
+            >
+              {loginErrorMessage}
+            </div>
+          )}
           <div style={{ marginBottom: 'var(--space-4)' }}>
             <label
               htmlFor="login-email"


### PR DESCRIPTION
# feat(auth): traducir errores de login de Supabase y mostrarlos inline en Login

## Contexto
Actualmente los errores de autenticación de Supabase se mostraban en inglés o en formato técnico.  
El objetivo fue interceptar esos errores y mostrar mensajes claros en español para el usuario final.

## Qué se implementó
- Se creó un diccionario centralizado de errores de auth en español.
- Se agregó una función traductora basada en `error.code` con fallback a mensaje genérico.
- Se actualizó `SupabaseAuthRepository.signIn()` para lanzar errores traducidos.
- En `LoginPage`, se removió la notificación tipo toast para errores de login.
- El error de login ahora se muestra dentro del formulario, arriba de los inputs, con estilo visual consistente.

## Archivos principales
- `src/infrastructure/modules/auth/errors/authErrorMessages.ts`
- `src/infrastructure/modules/auth/repositories/SupabaseAuthRepository.ts`
- `src/presentation/modules/auth/pages/LoginPage.tsx`

## Beneficio
- Mensajes más claros y amigables para usuarios hispanohablantes.
- Base escalable para reutilizar traducciones de errores en otros métodos de auth.

## Validación manual sugerida
- `invalid_credentials`
- `email_not_confirmed`
- `user_banned`
- `email_provider_disabled` o `provider_disabled`
- `over_request_rate_limit`

## Notas
- Si Supabase no envía `code`, se usa el mensaje por defecto en español.
