### PR TITLE
Actualización del botón de cerrar sesión y unificación de iconografía en la sección de acciones del usuario.

### DIFF
--- a/public/icons/system-icons.svg
+++ b/public/icons/system-icons.svg
@@ -463,5 +463,9 @@
     <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10"
       stroke-width="1.5"
       d="M21.25 12H8.895m-4.361 0H2.75m18.5 6.607h-5.748m-4.361 0H2.75m18.5-13.214h-3.105m-4.361 0H2.75m13.214 2.18a2.18 2.18 0 1 0 0-4.36a2.18 2.18 0 0 0 0 4.36Zm-9.25 6.607a2.18 2.18 0 1 0 0-4.36a2.18 2.18 0 0 0 0 4.36Zm6.607 6.608a2.18 2.18 0 1 0 0-4.361a2.18 2.18 0 0 0 0 4.36Z" />
+  <symbol id="icon-logout" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
   </symbol>
 </svg>

--- a/src/presentation/modules/notifications/components/NotificationBell.tsx
+++ b/src/presentation/modules/notifications/components/NotificationBell.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useNotificationsList, useMarkNotificationRead, useMarkAllNotificationsRead } from '@/presentation/modules/notifications/hooks/useNotifications';
-import { Icon } from '@/presentation/modules/shared/components/Sidebar/icons/Icon';
+import WcButtonIcon from '@/presentation/modules/shared/components/ui/webcomponents/Buttons/wcButtonIcon';
 import type { Notification } from '@/domain/modules/notifications/models/Notification';
 
 interface NotificationBellProps {
@@ -62,30 +62,21 @@ export function NotificationBell({ userId }: NotificationBellProps) {
 
   return (
     <div style={{ position: 'relative' }} ref={popoverRef}>
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="btn-ghost"
-        style={{
-          position: 'relative',
-          padding: '8px',
-          borderRadius: '50%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'pointer',
-          border: 'none',
-          background: isOpen ? 'var(--color-surface-hover)' : 'transparent',
-        }}
-      >
-        <span style={{ color: 'var(--color-text-secondary)', display: 'flex' }}>
-          <Icon name="icon-bell" size={20} />
-        </span>
+      <div style={{ position: 'relative', display: 'inline-block' }}>
+        <WcButtonIcon
+          variant="ghost"
+          shape="circle"
+          icon="icon-bell"
+          onClick={() => setIsOpen(!isOpen)}
+          style={{ background: isOpen ? 'var(--color-surface-hover)' : 'transparent' }}
+          aria-label="Notificaciones"
+        />
         {unreadCount > 0 && (
           <span
             style={{
               position: 'absolute',
-              top: '2px',
-              right: '2px',
+              top: '-2px',
+              right: '-2px',
               minWidth: '18px',
               height: '18px',
               borderRadius: '9px',
@@ -99,12 +90,13 @@ export function NotificationBell({ userId }: NotificationBellProps) {
               padding: '0 4px',
               border: '2px solid var(--color-surface)',
               lineHeight: 1,
+              pointerEvents: 'none'
             }}
           >
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
-      </button>
+      </div>
 
       {isOpen && (
         <div className="notification-popover">

--- a/src/presentation/modules/shared/components/ThemeToggle.tsx
+++ b/src/presentation/modules/shared/components/ThemeToggle.tsx
@@ -7,7 +7,7 @@ export function ThemeToggle() {
   
   return (
     <WcButtonIcon
-      variant="primary"
+      variant="ghost"
       shape="circle"
       icon={isDark ? 'icon-sun' : 'icon-moon'}
       title={isDark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'}

--- a/src/presentation/modules/shared/layouts/AppLayout.tsx
+++ b/src/presentation/modules/shared/layouts/AppLayout.tsx
@@ -3,7 +3,7 @@ import { usePresenceTracker } from "@/presentation/modules/users/hooks/usePresen
 import { useUserStore } from "@/presentation/modules/users/stores/useUserStore";
 import { useAdminUsers } from "@/presentation/modules/users/hooks/useAdminUsers";
 import { InviteUserModal } from "@/presentation/modules/users/components/InviteUserModal";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { ThemeToggle } from "@/presentation/modules/shared/components/ThemeToggle";
 import { UserProfileModal } from "@/presentation/modules/users/components/UserProfileModal";
@@ -17,11 +17,14 @@ import { usePatientStore } from "@/presentation/modules/patient/stores/usePatien
 import { PatientCreateModal } from "@/presentation/modules/patient/components/Patients/PatientCreateModal";
 import { PatientQuickSearchModal } from "@/presentation/modules/patient/components/Patients/PatientQuickSearchModal";
 import { QuickActionBar } from "@/presentation/modules/shared/components/QuickActionBar";
+import WcButtonIcon from "@/presentation/modules/shared/components/ui/webcomponents/Buttons/wcButtonIcon";
+import "@/presentation/modules/shared/components/ui/webcomponents/wcWarning";
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const { user, logout, isLoggingOut } = useAuth();
   const navigate = useNavigate();
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const warningRef = useRef<any>(null);
 
   const { setInviteModalOpen, isInviteModalOpen } = useUserStore();
   // Safe to use here because it's a hook wrapping react-query; calling loadUsers will fetch data
@@ -46,6 +49,10 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const handleLogout = async () => {
     await logout();
     navigate("/login");
+  };
+
+  const confirmLogout = () => {
+    warningRef.current?.open(handleLogout);
   };
 
   return (
@@ -130,15 +137,15 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             )}
             <NotificationBell userId={user?.id} />
             <ThemeToggle />
-            <button
-              type="button"
-              className="btn-ghost"
-              onClick={handleLogout}
+            <WcButtonIcon
+              variant="danger"
+              shape="circle"
+              icon="icon-logout"
+              onClick={confirmLogout}
               disabled={isLoggingOut}
-              style={{ fontSize: "var(--font-size-sm)" }}
-            >
-              {isLoggingOut ? "Saliendo..." : "Cerrar sesión"}
-            </button>
+              title={isLoggingOut ? "Saliendo..." : "Cerrar sesión"}
+              aria-label="Cerrar sesión"
+            />
           </div>
         </header>
 
@@ -267,6 +274,15 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           if (!isUsersLoaded) loadUsers();
         }}
         isInviting={isInviting}
+      />
+
+      <wc-warning
+        ref={warningRef}
+        title="Cerrar sesión"
+        message="¿Estás seguro de que deseas cerrar tu sesión actual?"
+        confirm-text="Cerrar sesión"
+        cancel-text="Cancelar"
+        type="warning"
       />
     </div>
   );


### PR DESCRIPTION
### Refactor del Header – Acciones de Usuario

Se completó el refactor de la sección de acciones de usuario en el header, cumpliendo con los requerimientos establecidos.

#### Botón **Cerrar Sesión**
- En `AppLayout.tsx` se reemplazó el botón nativo `<button>` por el componente reutilizable `<WcButtonIcon />`.
- Se aplicó la variante `danger` (rojo) y `shape="circle"` para destacar la acción de salida y mantener coherencia visual con los demás controles.
- Se integró el modal reutilizable `<wc-warning>`, invocado al hacer clic en cerrar sesión. Este solicita confirmación y, en caso afirmativo, ejecuta la lógica previa de `handleLogout`.

#### Unificación de Iconografía
- Se añadió el nuevo ícono `icon-logout` al sprite global `public/icons/system-icons.svg`, respetando el trazo consistente (`stroke-width: 2`).
- `NotificationBell.tsx` fue refactorizado para usar `<WcButtonIcon variant="ghost" shape="circle" icon="icon-bell" />`.  
  El badge rojo de notificación se posicionó mediante CSS absoluto, garantizando compatibilidad con el SVG nativo.
- `<ThemeToggle>` ahora utiliza la variante `ghost` con geometría circular, homogeneizando el diseño de la botonera del Header.

#### Interacción y Estilos
- Todos los botones de acciones aprovechan el encapsulamiento de `WcButtonIcon.css`, con estados sincronizados (hover, focus-visible, contrastes).
- En el panel de notificaciones, se mantiene la lógica de toggle: cuando el popover está abierto, el botón adquiere un fondo `var(--color-surface-hover)` para denotar selección activa, asegurando legibilidad en temas Light/Dark.
- El código se implementó de forma atómica, evitando regresiones en la sesión y en los hooks correspondientes.

### Imagenes
<img width="319" height="78" alt="image" src="https://github.com/user-attachments/assets/3143cbf1-1459-4e8a-8be3-5973cc8c198c" />
<img width="311" height="74" alt="image" src="https://github.com/user-attachments/assets/713ee01d-3de8-446d-b144-4ae71f597d48" />


