### PR TITLE
feat(notifications): scalable in-app notifications with rich UI and deep- links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,273 @@ El proyecto está estrictamente dividido en 4 capas. El código generado DEBE re
 - **Extensión de diseño:** Si falta una variante visual, extender el componente base por props/clase antes de crear uno nuevo.
 - **Consistencia de intención:** `WcButton` para acciones de flujo/intención; `WcButtonIcon` para acciones compactas y contextuales.
 - **Paginación por vista:** Definir constantes por modo (`table/cards`) y evitar números mágicos en JSX.
+
+---
+
+# Visión General del Sistema
+
+> Esta sección documenta el estado actual de las funcionalidades implementadas para que cualquier agente pueda extender el sistema respetando las convenciones existentes. Cualquier feature nueva DEBE reutilizar la infraestructura, hooks, componentes y patrones aquí descritos antes de crear código paralelo.
+
+## Estructura de Carpetas
+
+```
+src/
+  App.tsx                  Definición de rutas (createBrowserRouter)
+  main.tsx                 Bootstrap React + QueryClientProvider
+  domain/modules/          Entidades, enums e interfaces de repositorio
+  application/modules/     Casos de uso (clases con execute)
+  infrastructure/
+    core/supabaseClient.ts Cliente Supabase singleton
+    modules/               Implementaciones SupabaseXxxRepository + mappers
+  presentation/
+    core/
+      ui/                  Botones legacy (Button.tsx, index.ts)
+      security/            Permisos cliente (medicalRecordPermissions.ts)
+    modules/
+      <feature>/
+        pages/             Pantallas con routing
+        components/        UI compuesta del módulo
+        hooks/             Wrappers de TanStack Query sobre Use Cases
+        schemas/           Zod schemas (UNICO sitio permitido)
+        stores/            Zustand para UI efímera
+        utils/             Helpers locales del módulo
+```
+
+Módulos activos: `auth`, `catalog`, `dashboard`, `evolution`, `medical-record`, `notifications`, `patient`, `shared`, `users`.
+
+## Mapa de Rutas (`src/App.tsx`)
+
+| Ruta | Componente | Acceso |
+|---|---|---|
+| `/login` | `LoginPage` | Público |
+| `/update-password` | `UpdatePasswordPage` | Público (vía link de Supabase) |
+| `/` | `DashboardPage` | Autenticado |
+| `/pacientes` | `PatientsPage` | Autenticado |
+| `/pacientes/:patientId/historia` | `MedicalRecordPage` | Autenticado |
+| `/pacientes/:patientId/historia/evoluciones/:evolutionId` | `EvolutionWorkspacePage` | Autenticado |
+| `/historias-clinicas` | `MedicalRecordsPage` | Autenticado |
+| `/evoluciones` | `EvolutionsPage` | Autenticado |
+| `/admin/users` | `UsersManagementPage` | `admin` |
+| `*` | Redirección a `/` | - |
+
+Todas las rutas protegidas están envueltas en `ProtectedRoute` (con prop `allowedRoles`) y `AppLayout` (sidebar + header + acciones globales).
+
+## Integración Supabase
+
+- Cliente singleton en `src/infrastructure/core/supabaseClient.ts` que lee `VITE_SUPABASE_URL` y `VITE_SUPABASE_PUBLISHABLE_KEY` (fallback `VITE_SUPABASE_ANON_KEY`).
+- Toda la seguridad de datos depende de **RLS** en PostgreSQL.
+- Funcionalidades Supabase usadas: Auth, Database (`from`), RPC, Edge Functions, Storage (bucket `avatars`), Realtime (presence + cambios de tabla).
+- Mappers (`snake_case` ↔ `camelCase`) viven en `infrastructure/modules/<feature>/mappers/`. Los dominios NUNCA conocen snake_case.
+
+### RPCs Disponibles
+- `search_cie10(query, result_limit)` (catalog)
+- `get_medical_record_evolution_counts(record_ids)` (medical-record)
+- `get_all_users_admin`, `get_filtered_users_admin`, `toggle_user_status`, `soft_delete_user`, `restore_deleted_user` (users)
+
+### Edge Functions
+- `invite-user` (users) - envía invitación con redirect_to.
+
+### Realtime
+- `online-users` channel (presence) en users.
+- Suscripciones para notificaciones, perfiles y pacientes invalidan caché de TanStack Query vía `queryClient.invalidateQueries`.
+
+## Módulos Implementados
+
+### 1. Auth (`auth`)
+Login con email/password, recuperación de contraseña por email, actualización de contraseña tras link de reset, protección por rol y verificación de `account_status === "active"`.
+
+- Domain: `AuthRepository` (signIn, signOut, getCurrentUser, onAuthStateChange, sendPasswordResetEmail, updatePassword) - el modelo `UserProfile` reside en `domain/modules/users`.
+- Application: `LoginUser`, `LogoutUser`, `SendPasswordResetEmailUseCase`, `UpdatePasswordUseCase`.
+- Infrastructure: `SupabaseAuthRepository` con traducción de errores en `errors/authErrorMessages.ts` (mensajes en español).
+- Presentation:
+  - Pages: `LoginPage`, `UpdatePasswordPage`.
+  - Components: `ProtectedRoute` (soporta `allowedRoles`).
+  - Hooks: `useAuth`, `usePasswordReset`, `useUpdatePassword`.
+  - Schemas: `auth.schema.ts` (login, reset, update password).
+
+### 2. Catalog (`catalog`)
+Catálogos maestros, búsqueda CIE-10 y búsqueda jerárquica de ubicación geográfica (Ecuador: provincia/cantón/parroquia/DPA).
+
+- Domain: enums normalizados (`GenderEnum`, `BloodTypeEnum`, `MaritalStatusEnum`, `CulturalGroupEnum`, `EducationLevelEnum`, `InformationSourceEnum`, `KinshipEnum`, `AntecedentTypeEnum`, `HealthInsuranceTypeEnum`), `Catalog`, `CatalogItem`, `Cie10Pathology`, `Cie10SearchResult`, `GeographicLocation`.
+- Application: `ListCatalogsUseCase`, `ListCatalogItemsUseCase`, `SearchCie10PathologiesUseCase` (min 2 chars), `SearchGeographicLocationsUseCase` (min 3 chars).
+- Infrastructure: `SupabaseCatalogRepository` (consulta tablas `catalogs`, `catalog_items`, `geographic_locations` y RPC `search_cie10`).
+- Presentation:
+  - Hooks: `useCatalogs`, `useCatalogItems`, `useSearchCie10Pathologies`, `useSearchGeographicLocations`.
+  - Reutilizado por: Patient (autocomplete CIE-10, ubicación, ocupación) y Evolution (diagnósticos CIE-10).
+
+### 3. Dashboard (`dashboard`)
+Landing autenticado con bienvenida y datos del perfil actual.
+
+- Pages: `DashboardPage`.
+
+### 4. Patient (`patient`)
+CRUD completo del paciente con relaciones (contactos de emergencia, antecedentes clínicos), búsqueda avanzada, ficha rápida, drawer de detalle y soft-delete (toggle `is_active`).
+
+- Domain: `Patient` (40+ campos: identidad, contacto, demografía, empleo, dirección, fuente de información), `PatientEmergencyContact`, `PatientClinicalAntecedent`, DTOs `CreatePatientDTO` / `UpdatePatientDTO`, `PatientListItem`, `PatientFilters`.
+- Application: `CreatePatientUseCase` (valida duplicado de `idNumber`), `GetPatientUseCase`, `GetPatientByIdNumberUseCase`, `ListPatientsUseCase`, `UpdatePatientUseCase`, `TogglePatientStatusUseCase`.
+- Infrastructure: `SupabasePatientRepository` con manejo manual de upsert/soft-delete para `patient_clinical_antecedents` y reemplazo total para `patient_emergency_contacts`. Carga relaciones anidadas (`occupation`, `geographic_location`, `patient_emergency_contacts`, `patient_clinical_antecedents.pathology`).
+- Presentation:
+  - Pages: `PatientsPage` (lista + filtros + creación).
+  - Components: `PatientsList`, `PatientSearchFilters`, `PatientQuickFilterPopover`, `PatientQuickSearchModal`, `PatientDetailsDrawer`, `PatientCreateModal`, `Cie10SearchInput`, `GeographicLocationSearchInput`.
+  - Hooks: `usePatients`, `usePatient`, `usePatientByIdNumber`, `useCreatePatient`, `useUpdatePatient`, `useTogglePatientStatus`, `usePatientSubscription` (realtime).
+  - Store: `usePatientStore` (modales, filtros, paciente seleccionado).
+  - Schemas: `patient.schema.ts` (incluye validación de cédula ecuatoriana vía `validateEcCedula` del módulo `shared`).
+
+### 5. Medical Record (`medical-record`)
+Historia clínica única por paciente. Incluye listado global de historias, configuración de la organización (cabecera institucional MSP) y vista detallada con resumen + evoluciones asociadas.
+
+- Domain: `MedicalRecord`, `MedicalRecordListItem`, `MedicalRecordFilters`, `OrganizationConfig`, `PaginatedResult<T>`.
+- Application: `CreateMedicalRecordUseCase`, `GetMedicalRecordByPatientUseCase`, `ListMedicalRecordsUseCase` (valida rango ≤ 31 días), `UpdateMedicalRecordStatusUseCase`, `GetOrganizationConfigUseCase`, `UpdateOrganizationConfigUseCase`.
+- Infrastructure: `SupabaseMedicalRecordRepository` (joins con `patients` y `profiles` para creator/updater, RPC `get_medical_record_evolution_counts` para conteo eficiente de evoluciones), `SupabaseOrganizationConfigRepository`.
+- Presentation:
+  - Pages: `MedicalRecordsPage` (lista global), `MedicalRecordPage` (detalle por paciente).
+  - Components: `MedicalRecordHeader`, `MedicalRecordSummary`, `MedicalRecordEvolutionsList`, `CreateMedicalRecordModal`, `MedicalRecordDetailsModal`, `MedicalRecordsList`, `MedicalRecordsSearchFilters`, `MedicalRecordsDateFilterPopover`, `OrganizationConfigModal`.
+  - Hooks: `useMedicalRecords`, `useMedicalRecordByPatient`, `useCreateMedicalRecord`, `useUpdateMedicalRecord`, `useOrganizationConfig`.
+  - Store: `useMedicalRecordStore`.
+  - Schemas: `organizationConfig.schema.ts`.
+  - Permisos: `presentation/core/security/medicalRecordPermissions.ts`.
+
+### 6. Evolution (`evolution`)
+Atenciones / notas evolutivas asociadas a una historia clínica. Incluye flujo emergencia ambulatoria, signos vitales, examen físico, lesiones, diagnósticos CIE-10 (ingreso/alta, presuntivo/definitivo), emergencia obstétrica y alta médica. Estados `ABIERTA`, `EN_PROCESO`, `CERRADA`.
+
+- Domain: `MedicalEvolution` (50+ campos), `MedicalEvolutionListItem`, `EvolutionFilters`, `EvolutionSystemReview`, `EvolutionPhysicalExam`, `EvolutionInjury`, `EvolutionDiagnosis`, `EvolutionDischarge`, payloads `CreateEvolutionPayload` / `UpdateEvolutionPayload` + enums (`EvolutionStatus`, `ArrivalMethod`, `ClinicalCause`, `AccidentType`, `ViolenceType`, `IntoxicationType`, `DiagnosisType`, `DiagnosisCertainty`, `SystemReviewCondition`, `PhysicalExamRegion`, `InjuryType`, `DischargeType`).
+- Application: `CreateEvolutionUseCase`, `UpdateEvolutionUseCase`, `GetEvolutionByIdUseCase`, `GetEvolutionsByMedicalRecordUseCase`, `ListEvolutionsUseCase` (rango ≤ 31 días), `CloseEvolutionUseCase` (marca `CERRADA`, registra `closed_by` y `closed_at`).
+- Infrastructure: `SupabaseEvolutionRepository` que reemplaza relaciones (systems_review, physical_exams, injuries, diagnoses, discharges) en cada update, con joins profundos a `profiles` (opener/closer) y `cie10_pathologies`.
+- Presentation:
+  - Pages: `EvolutionsPage` (tabs "Últimas 48 horas" + "Consulta avanzada"), `EvolutionWorkspacePage` (workspace tabbed).
+  - Tabs del workspace: `TabAdmision`, `TabMotivo`, `TabEmergenciaObstetrica` (solo femenino), `TabSignosVitales` (autocálculo IMC), `TabExamen`, `TabDiagnostico`, `TabAlta`.
+  - Components: `CreateEvolutionModal`, `EvolutionResultsTable`, `UnsavedChangesModal`.
+  - Hooks: `useEvolutions`, `useEvolutionsByMedicalRecord`, `useEvolution`, `useCreateEvolution`, `useUpdateEvolution`, `useCloseEvolution`.
+  - Stores: `useEvolutionUIStore` (tab activa, modales), `useEvolutionsListStore` (filtros/paginación).
+  - Schemas: `evolution.schema.ts` (validación estricta + relajada para borradores).
+  - Utils: `dateRange.ts`.
+
+### 7. Notifications (`notifications`)
+Centro de notificaciones in-app con conteo de no leídas, marcar como leída individual o masivamente, y actualización en tiempo real.
+
+- Domain: `Notification`, `KnownNotificationType` (`NEW_USER` | `NEW_PATIENT` | `NEW_MEDICAL_RECORD` | `NEW_EVOLUTION` | `TASK_ASSIGNED` | `SYSTEM_ALERT`), `NotificationType` (unión abierta).
+- Application: `NotificationService` (servicio agrupado: `getNotifications`, `markAsRead`, `markAllAsRead`).
+- Infrastructure: `SupabaseNotificationRepository` con resolución batch de `actor_id` (anti N+1). Singleton instanciado en `infrastructure/modules/notifications/config.ts`.
+- Backend (`supabase/migrations/`, repo separado):
+  - `10_notifications_schema.sql`: tabla `notifications`, RLS y helper legacy `notify_user`.
+  - `11_notify_new_user_trigger.sql`: trigger `on_new_user_notify_admins` → `NEW_USER` solo a admins activos.
+  - `15_medical_records_schema.sql`: trigger `on_medical_record_created` → `NEW_MEDICAL_RECORD`.
+  - `26_notifications_realtime_and_helpers.sql`: añade `notifications` a la publication `supabase_realtime` y crea el helper genérico `public.notify_users(actor, type, entity_id, roles?, exclude_self?)` que filtra automáticamente por `account_status='active'` y `deleted_at IS NULL`. Refactoriza `NEW_USER` y `NEW_MEDICAL_RECORD` para consumirlo.
+  - `27_notify_new_patient_trigger.sql`: trigger `on_patient_created_notify` → `NEW_PATIENT`.
+  - `28_notify_new_evolution_trigger.sql`: trigger `on_evolution_created_notify` → `NEW_EVOLUTION` (actor = `opened_by`).
+- Presentation:
+  - Components: `NotificationBell` (popover en `AppLayout`).
+  - Hooks: `useNotificationsList`, `useMarkNotificationRead(userId)`, `useMarkAllNotificationsRead(userId)`, `useNotificationSubscription` (realtime).
+  - Registry: `registry/notificationRegistry.ts` — fuente única de verdad para icono, variante de toast, mensaje y ruta por tipo de notificación.
+
+#### Receta: Agregar una notificación para un módulo nuevo
+1. **Backend**: crear migración `XX_notify_new_<entity>_trigger.sql` con una función `SECURITY DEFINER` que llame a `public.notify_users(NEW.<actor_column>, '<TIPO>', NEW.id, <roles?>, TRUE)` y un trigger `AFTER INSERT` sobre la tabla destino. Reutilizar siempre el helper, nunca duplicar el loop por perfiles.
+2. **Domain**: añadir el literal al union `KnownNotificationType` en `domain/modules/notifications/models/Notification.ts`.
+3. **Registry**: agregar una entrada en `NOTIFICATION_REGISTRY` (en `presentation/modules/notifications/registry/notificationRegistry.ts`) con `icon` (id válido en `system-icons.svg`), `toastVariant`, `toastTitle`, `getMessage(notification, currentUserId)` y `getRoute(notification)` opcional.
+4. **NO** modificar `NotificationBell.tsx` ni `useNotificationSubscription.ts`: ambos consumen el registry y soportan tipos nuevos automáticamente.
+
+### 8. Users (`users`)
+Administración de usuarios solo para `admin`: invitación (Edge Function), edición de perfil con avatar (Storage + crop), cambio de estado (`active` / `inactive` / `suspended`), soft delete y restore, presencia online en tiempo real (presence channel), vista en tabla y cards.
+
+- Domain: `UserProfile`, `UserWithPresence`, `PresenceEntry`, `InviteUserPayload`, `UserFilters` y enums (`UserRole`: admin, doctor, nurse, receptionist, lab_technician, pharmacist; `AccountStatus`: active, inactive, suspended). Constantes `USER_ROLE_LABELS` y `ACCOUNT_STATUS_LABELS` para etiquetas en español.
+- Application: `GetFilteredUsers`, `InviteUser`, `ToggleUserStatus`, `SoftDeleteUser`, `RestoreDeletedUser`, `UpdateUserProfileUseCase` (orquesta subida/borrado de avatar vía `StorageRepository` con path `{userId}/{timestamp}.{ext}`).
+- Infrastructure: `SupabaseUserRepository` (RPCs de admin, edge function `invite-user`, presence channel `online-users`).
+- Presentation:
+  - Pages: `UsersManagementPage` (tabla / cards, filtros, acciones).
+  - Components: `InviteUserModal`, `UserProfileModal`, `UserUpdatePasswordModal`, `UsersQuickFilterPopover`, `ActiveUsersFloat`, `wcUserCard`.
+  - Hooks: `useAdminUsers`, `useUpdateProfile`, `usePresenceTracker`, `usePresenceSubscription`, `useProfilesSubscription`.
+  - Store: `useUserStore`.
+  - Schemas: `user.schema.ts`, `admin.schema.ts`.
+
+### 9. Shared (`shared`)
+Capa transversal con utilidades, validadores, storage y la librería de UI (`Wc*`).
+
+- Domain: `StorageRepository` (avatares), `validateEcCedula` (algoritmo Módulo 10 ecuatoriano: 10 dígitos, provincia 01-24, tercer dígito 0-5).
+- Infrastructure: `SupabaseStorageRepository` (bucket `avatars`, upsert + cacheControl 3600, generación de public URL y borrado tolerante a errores).
+- Presentation:
+  - Layout: `AppLayout` (sidebar pinable con hover-flyout, header con notificaciones, theme toggle, logout, `QuickActionBar`, `ActiveUsersFloat`, modales globales y `Toaster`).
+  - Webcomponents (`presentation/modules/shared/components/ui/webcomponents/`):
+    - `WcButton`, `WcButtonIcon`
+    - `WcSearchInput`, `WcTextareaExpand`
+    - `WcTables` (+ `TableAvatarCell`, `TableStatusBadge`, `TableActionCell`, `TableIconButton`)
+    - `WcTabsFolder` (tabs con iconos y estado de error)
+    - `WcModal`, `WcWarning`
+    - `WcModuleHeader` (cabecera estándar de página con título, descripción, popover informativo y slot de acciones)
+    - `WcFilterPopover`, `WcFilterTag`, `WcFilterTags`, `WcTag`
+  - Otros componentes: `Sidebar`, `Icon` (consume `public/system-icons.svg` vía `<symbol>`), `EkLogo`, `Footer`, `PasswordInput`, `ThemeToggle`, `Toaster`, `ConfirmDialog` + `useConfirmDialog`, `ImageCropperModal`, `QuickActionBar`.
+  - Hooks: `useDebounce`.
+  - Store: `themeStore` (light/dark).
+  - Utils: `imageUtils.ts` (procesado de imágenes para crop de avatar).
+
+## Patrones Convencionales del Proyecto
+
+### Paginación
+Interfaz uniforme `PaginatedResult<T> = { data: T[]; total: number; page: number; limit: number }`. En Supabase se implementa con `range(from, to)` + `count: "exact"`. Los casos de uso de listas suelen validar que el rango de fechas no exceda 31 días.
+
+### Soft Deletes
+- Usuarios: `deleted_at` + RPC `soft_delete_user` / `restore_deleted_user`.
+- Pacientes / Historias / Catálogos: flag `is_active`.
+- Antecedentes clínicos: flag `is_active` con upsert manual.
+
+### Búsquedas
+- CIE-10: RPC `search_cie10` (full-text con ranking).
+- Ubicación geográfica: `ilike` combinado en DPA + provincia + cantón + parroquia.
+- Listas: `ilike` con prefijo/sufijo `%` o combinaciones `or(...)`.
+- Toda search input usa `useDebounce` con `WcSearchInput`.
+
+### Hooks Pattern
+1. Instanciar repo (`new SupabaseXxxRepository()`).
+2. Instanciar use case (`new XxxUseCase(repo)`).
+3. Envolver en `useQuery` / `useMutation`.
+4. Invalidar `queryClient.invalidateQueries({ queryKey: [...] })` tras mutaciones o eventos realtime.
+
+### Realtime
+- Suscripciones se inicializan en hooks `useXxxSubscription` montados en `AppLayout` o pantallas relevantes.
+- Nunca mutar caché manualmente: solo invalidar queryKeys.
+- Presence: canal `online-users` se sincroniza vía `usePresenceTracker` (track) y `usePresenceSubscription` (sync).
+
+### Formularios
+- React Hook Form + `@hookform/resolvers/zod`.
+- Schemas en `presentation/modules/<feature>/schemas/`.
+- Errores se mapean a la tab correspondiente en flujos con `WcTabsFolder` (ver `EvolutionWorkspacePage`).
+- Strict vs relaxed: borradores usan schema relajado; al cerrar/firmar se aplica schema estricto.
+
+### Iconografía
+Sprite SVG en `public/system-icons.svg`. Acceso vía `<Icon name="..." />`. Para añadir un icono nuevo, agregar un `<symbol id="...">` al sprite y referenciarlo por id; nunca pegar SVG inline en componentes.
+
+## Convenciones para Añadir un Nuevo Módulo
+
+1. **Domain (`src/domain/modules/<feature>/`)**
+   - `models/Xxx.ts` con `interface`/`type` (sin dependencias externas).
+   - `repositories/XxxRepository.ts` con la interfaz pública.
+2. **Application (`src/application/modules/<feature>/use-cases/`)**
+   - Una clase por caso de uso con `execute(...)`. Sin propiedades de parámetros en el constructor (asignar en el cuerpo).
+   - Validaciones de negocio y traducción a errores genéricos en español.
+3. **Infrastructure (`src/infrastructure/modules/<feature>/`)**
+   - `repositories/SupabaseXxxRepository.ts` implementando la interfaz del dominio.
+   - `mappers/xxxMapper.ts` para snake_case ↔ camelCase.
+   - Si requiere RLS especial o RPC, documentar la dependencia del backend en el PR.
+4. **Presentation (`src/presentation/modules/<feature>/`)**
+   - `pages/`, `components/`, `hooks/`, `schemas/`, `stores/`, `utils/` según necesidad.
+   - Página principal usa `WcModuleHeader` y se monta dentro de `AppLayout` desde `App.tsx`.
+   - Estado servidor SIEMPRE vía TanStack Query; UI efímera vía Zustand sin `persist` cuando contenga PII.
+5. **Routing (`src/App.tsx`)**
+   - Añadir la ruta envuelta en `ProtectedRoute` y `AppLayout`.
+   - Si requiere rol restringido, pasar `allowedRoles={[...]}`.
+6. **Logout / Cleanup**
+   - Si el módulo agrega un store de Zustand con datos sensibles, asegúrese de resetearlo en el flujo de logout junto con `queryClient.clear()`.
+7. **Notificaciones (si aplica)**
+   - Si el módulo emite eventos que otros usuarios deberían saber (creación de entidad, asignación, alerta), seguir la receta del módulo `notifications` (ver sección **7. Notifications → Receta: Agregar una notificación para un módulo nuevo**). Resumen: 1 migración SQL invocando `public.notify_users(...)`, 1 literal en `KnownNotificationType`, 1 entrada en `NOTIFICATION_REGISTRY`. **Nunca** duplicar el loop de inserción en triggers ni el switch de mensajes en `NotificationBell`.
+
+## Scripts del Proyecto
+
+```bash
+pnpm dev          # Vite dev server
+pnpm build        # tsc -b && vite build (verificación de tipos obligatoria)
+pnpm lint         # oxlint .
+pnpm lint:fix     # oxlint --fix
+pnpm preview      # Preview del build
+```
+
+Antes de marcar una tarea como completada, ejecutar como mínimo `pnpm lint` y, si se tocaron tipos públicos o esquemas, `pnpm build` para validar el typecheck.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,9 +221,9 @@ Atenciones / notas evolutivas asociadas a una historia clínica. Incluye flujo e
 ### 7. Notifications (`notifications`)
 Centro de notificaciones in-app con conteo de no leídas, marcar como leída individual o masivamente, y actualización en tiempo real.
 
-- Domain: `Notification`, `KnownNotificationType` (`NEW_USER` | `NEW_PATIENT` | `NEW_MEDICAL_RECORD` | `NEW_EVOLUTION` | `TASK_ASSIGNED` | `SYSTEM_ALERT`), `NotificationType` (unión abierta).
+- Domain: `Notification` (incluye `metadata: NotificationMetadata`), `KnownNotificationType` (`NEW_USER` | `NEW_PATIENT` | `NEW_MEDICAL_RECORD` | `NEW_EVOLUTION` | `TASK_ASSIGNED` | `SYSTEM_ALERT`), `NotificationType` (unión abierta).
 - Application: `NotificationService` (servicio agrupado: `getNotifications`, `markAsRead`, `markAllAsRead`).
-- Infrastructure: `SupabaseNotificationRepository` con resolución batch de `actor_id` (anti N+1). Singleton instanciado en `infrastructure/modules/notifications/config.ts`.
+- Infrastructure: `SupabaseNotificationRepository` lee `metadata` desde la fila y deriva `actorName` desde `metadata.actorName`. Ya **no** consulta `profiles` (lo cual fallaba con RLS para no-admins).
 - Backend (`supabase/migrations/`, repo separado):
   - `10_notifications_schema.sql`: tabla `notifications`, RLS y helper legacy `notify_user`.
   - `11_notify_new_user_trigger.sql`: trigger `on_new_user_notify_admins` → `NEW_USER` solo a admins activos.
@@ -231,15 +231,20 @@ Centro de notificaciones in-app con conteo de no leídas, marcar como leída ind
   - `26_notifications_realtime_and_helpers.sql`: añade `notifications` a la publication `supabase_realtime` y crea el helper genérico `public.notify_users(actor, type, entity_id, roles?, exclude_self?)` que filtra automáticamente por `account_status='active'` y `deleted_at IS NULL`. Refactoriza `NEW_USER` y `NEW_MEDICAL_RECORD` para consumirlo.
   - `27_notify_new_patient_trigger.sql`: trigger `on_patient_created_notify` → `NEW_PATIENT`.
   - `28_notify_new_evolution_trigger.sql`: trigger `on_evolution_created_notify` → `NEW_EVOLUTION` (actor = `opened_by`).
+  - `29_notifications_metadata.sql`: agrega la columna `notifications.metadata JSONB`, extiende `public.notify_users(... , p_metadata JSONB)` y refactoriza todos los triggers para escribir un payload denormalizado (`actorName`, `subjectName/Email/Role`, `patientName`, `patientIdNumber`, `evolutionStatus`). Esto elimina el JOIN a `profiles` desde el cliente y evita problemas con RLS para no-admins. Incluye el helper `public.get_profile_full_name(uuid)`.
 - Presentation:
   - Components: `NotificationBell` (popover en `AppLayout`).
   - Hooks: `useNotificationsList`, `useMarkNotificationRead(userId)`, `useMarkAllNotificationsRead(userId)`, `useNotificationSubscription` (realtime).
   - Registry: `registry/notificationRegistry.ts` — fuente única de verdad para icono, variante de toast, mensaje y ruta por tipo de notificación.
 
 #### Receta: Agregar una notificación para un módulo nuevo
-1. **Backend**: crear migración `XX_notify_new_<entity>_trigger.sql` con una función `SECURITY DEFINER` que llame a `public.notify_users(NEW.<actor_column>, '<TIPO>', NEW.id, <roles?>, TRUE)` y un trigger `AFTER INSERT` sobre la tabla destino. Reutilizar siempre el helper, nunca duplicar el loop por perfiles.
-2. **Domain**: añadir el literal al union `KnownNotificationType` en `domain/modules/notifications/models/Notification.ts`.
-3. **Registry**: agregar una entrada en `NOTIFICATION_REGISTRY` (en `presentation/modules/notifications/registry/notificationRegistry.ts`) con `icon` (id válido en `system-icons.svg`), `toastVariant`, `toastTitle`, `getMessage(notification, currentUserId)` y `getRoute(notification)` opcional.
+1. **Backend**: crear migración `XX_notify_new_<entity>_trigger.sql` con una función `SECURITY DEFINER` que:
+   - Construye un `payload JSONB` con todos los datos que la UI necesitará para renderizar (mínimo `actorName` vía `public.get_profile_full_name(...)`, más los campos propios de la entidad). Esto es **obligatorio**: el cliente NO puede leer otras tablas para enriquecer notificaciones debido a RLS.
+   - Llama `public.notify_users(NEW.<actor_column>, '<TIPO>', NEW.id, <roles?>, TRUE, payload)`.
+   - Atrapa excepciones con `RAISE WARNING` para no romper el INSERT primario.
+   - Adjunta un `AFTER INSERT` trigger sobre la tabla destino. **Reutilizar siempre** el helper `notify_users`, nunca duplicar el loop por perfiles.
+2. **Domain**: añadir el literal al union `KnownNotificationType` en `domain/modules/notifications/models/Notification.ts`. Si introduces campos nuevos en metadata, extender `NotificationMetadata`.
+3. **Registry**: agregar una entrada en `NOTIFICATION_REGISTRY` (en `presentation/modules/notifications/registry/notificationRegistry.ts`) con `icon` (id válido en `system-icons.svg`), `toastVariant`, `toastTitle`, `getMessage(notification, currentUserId)` consumiendo `notification.metadata.*`, y `getRoute(notification)` opcional.
 4. **NO** modificar `NotificationBell.tsx` ni `useNotificationSubscription.ts`: ambos consumen el registry y soportan tipos nuevos automáticamente.
 
 ### 8. Users (`users`)

--- a/src/domain/modules/notifications/models/Notification.ts
+++ b/src/domain/modules/notifications/models/Notification.ts
@@ -8,6 +8,17 @@ export type KnownNotificationType =
 
 export type NotificationType = KnownNotificationType | (string & {});
 
+export interface NotificationMetadata {
+  actorName?: string | null;
+  subjectName?: string | null;
+  subjectEmail?: string | null;
+  subjectRole?: string | null;
+  patientName?: string | null;
+  patientIdNumber?: string | null;
+  evolutionStatus?: string | null;
+  [key: string]: unknown;
+}
+
 export interface Notification {
   id: string;
   recipientId: string;
@@ -15,6 +26,7 @@ export interface Notification {
   actorName: string | null;
   type: NotificationType;
   entityId: string | null;
+  metadata: NotificationMetadata;
   isRead: boolean;
   createdAt: Date;
 }

--- a/src/domain/modules/notifications/models/Notification.ts
+++ b/src/domain/modules/notifications/models/Notification.ts
@@ -13,6 +13,7 @@ export interface NotificationMetadata {
   subjectName?: string | null;
   subjectEmail?: string | null;
   subjectRole?: string | null;
+  patientId?: string | null;
   patientName?: string | null;
   patientIdNumber?: string | null;
   evolutionStatus?: string | null;

--- a/src/domain/modules/notifications/models/Notification.ts
+++ b/src/domain/modules/notifications/models/Notification.ts
@@ -1,4 +1,12 @@
-export type NotificationType = 'NEW_PATIENT' | 'NEW_EVOLUTION' | 'TASK_ASSIGNED' | 'SYSTEM_ALERT' | string;
+export type KnownNotificationType =
+  | 'NEW_USER'
+  | 'NEW_PATIENT'
+  | 'NEW_MEDICAL_RECORD'
+  | 'NEW_EVOLUTION'
+  | 'TASK_ASSIGNED'
+  | 'SYSTEM_ALERT';
+
+export type NotificationType = KnownNotificationType | (string & {});
 
 export interface Notification {
   id: string;

--- a/src/infrastructure/modules/notifications/repositories/SupabaseNotificationRepository.ts
+++ b/src/infrastructure/modules/notifications/repositories/SupabaseNotificationRepository.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 import type { NotificationRepository } from '@/domain/modules/notifications/repositories/NotificationRepository';
-import type { Notification } from '@/domain/modules/notifications/models/Notification';
+import type { Notification, NotificationMetadata } from '@/domain/modules/notifications/models/Notification';
 
 export class SupabaseNotificationRepository implements NotificationRepository {
   private readonly supabase: SupabaseClient;
@@ -12,7 +12,7 @@ export class SupabaseNotificationRepository implements NotificationRepository {
   async getNotifications(userId: string): Promise<Notification[]> {
     const { data, error } = await this.supabase
       .from('notifications')
-      .select('*')
+      .select('id, recipient_id, actor_id, type, entity_id, metadata, is_read, created_at')
       .eq('recipient_id', userId)
       .order('created_at', { ascending: false });
 
@@ -22,36 +22,7 @@ export class SupabaseNotificationRepository implements NotificationRepository {
 
     if (!data || data.length === 0) return [];
 
-    const actorIds = [...new Set(
-      data.map((row) => row.actor_id).filter(Boolean)
-    )] as string[];
-
-    const actorMap = new Map<string, string>();
-
-    if (actorIds.length > 0) {
-      const { data: actors } = await this.supabase
-        .from('profiles')
-        .select('id, first_name, last_name')
-        .in('id', actorIds);
-
-      if (actors) {
-        for (const actor of actors) {
-          const name = [actor.first_name, actor.last_name].filter(Boolean).join(' ');
-          if (name) actorMap.set(actor.id, name);
-        }
-      }
-    }
-
-    return data.map((row) => ({
-      id: row.id,
-      recipientId: row.recipient_id,
-      actorId: row.actor_id,
-      actorName: row.actor_id ? (actorMap.get(row.actor_id) ?? null) : null,
-      type: row.type,
-      entityId: row.entity_id,
-      isRead: row.is_read,
-      createdAt: new Date(row.created_at),
-    }));
+    return data.map((row) => toDomain(row));
   }
 
   async markAsRead(notificationId: string): Promise<void> {
@@ -76,4 +47,35 @@ export class SupabaseNotificationRepository implements NotificationRepository {
       throw new Error(`Error marking all notifications as read: ${error.message}`);
     }
   }
+}
+
+interface NotificationRow {
+  id: string;
+  recipient_id: string;
+  actor_id: string | null;
+  type: string;
+  entity_id: string | null;
+  metadata: NotificationMetadata | null;
+  is_read: boolean;
+  created_at: string;
+}
+
+function toDomain(row: NotificationRow): Notification {
+  const metadata: NotificationMetadata = row.metadata ?? {};
+  const actorNameFromMetadata =
+    typeof metadata.actorName === 'string' && metadata.actorName.trim().length > 0
+      ? metadata.actorName
+      : null;
+
+  return {
+    id: row.id,
+    recipientId: row.recipient_id,
+    actorId: row.actor_id,
+    actorName: actorNameFromMetadata,
+    type: row.type,
+    entityId: row.entity_id,
+    metadata,
+    isRead: row.is_read,
+    createdAt: new Date(row.created_at),
+  };
 }

--- a/src/presentation/modules/notifications/components/NotificationBell.tsx
+++ b/src/presentation/modules/notifications/components/NotificationBell.tsx
@@ -1,13 +1,32 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useNotificationsList, useMarkNotificationRead, useMarkAllNotificationsRead } from '@/presentation/modules/notifications/hooks/useNotifications';
-import { describeNotification } from '@/presentation/modules/notifications/registry/notificationRegistry';
+import { describeNotification, type NotificationStatusTone } from '@/presentation/modules/notifications/registry/notificationRegistry';
 import WcButtonIcon from '@/presentation/modules/shared/components/ui/webcomponents/Buttons/wcButtonIcon';
 import { Icon } from '@/presentation/modules/shared/components/Sidebar/icons/Icon';
 import type { Notification } from '@/domain/modules/notifications/models/Notification';
 
 interface NotificationBellProps {
   userId: string | undefined;
+}
+
+const STATUS_TONE_STYLES: Record<NotificationStatusTone, { background: string; color: string }> = {
+  info:    { background: 'rgba(59, 130, 246, 0.12)',  color: '#1D4ED8' },
+  success: { background: 'rgba(16, 185, 129, 0.12)',  color: '#047857' },
+  warning: { background: 'rgba(245, 158, 11, 0.15)',  color: '#B45309' },
+  neutral: { background: 'rgba(148, 163, 184, 0.15)', color: '#475569' },
+};
+
+function formatRelativeTime(createdAt: Date): string {
+  const diffMs = Date.now() - createdAt.getTime();
+  if (diffMs < 60_000) return 'hace unos segundos';
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 60) return `hace ${diffMin} min`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `hace ${diffH} h`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 7) return `hace ${diffD} d`;
+  return createdAt.toLocaleDateString();
 }
 
 export function NotificationBell({ userId }: NotificationBellProps) {
@@ -89,8 +108,8 @@ export function NotificationBell({ userId }: NotificationBellProps) {
 
       {isOpen && (
         <div className="notification-popover">
-          <div style={{ 
-            padding: '16px', 
+          <div style={{
+            padding: '16px',
             borderBottom: '1px solid var(--color-border)',
             display: 'flex',
             justifyContent: 'space-between',
@@ -127,16 +146,20 @@ export function NotificationBell({ userId }: NotificationBellProps) {
             ) : (
               notifications.map((notification) => {
                 const descriptor = describeNotification(notification.type);
+                const content = descriptor.getContent(notification, userId);
+                const isClickable = Boolean(descriptor.getRoute?.(notification));
                 return (
                   <div
                     key={notification.id}
                     onClick={() => handleNotificationClick(notification)}
+                    role={isClickable ? 'button' : undefined}
+                    tabIndex={isClickable ? 0 : undefined}
                     style={{
-                      padding: '12px 16px',
+                      padding: '14px 16px',
                       borderBottom: '1px solid var(--color-border)',
                       background: notification.isRead ? 'transparent' : 'var(--color-primary-light)',
-                      cursor: 'pointer',
-                      transition: 'background 0.2s ease',
+                      cursor: isClickable ? 'pointer' : 'default',
+                      transition: 'background 0.15s ease',
                       display: 'flex',
                       gap: '12px',
                       alignItems: 'flex-start',
@@ -151,10 +174,12 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                     <div
                       style={{
                         flex: '0 0 auto',
-                        width: '32px',
-                        height: '32px',
+                        width: '36px',
+                        height: '36px',
                         borderRadius: '50%',
-                        background: 'var(--color-surface-hover)',
+                        background: notification.isRead
+                          ? 'var(--color-surface-hover)'
+                          : 'rgba(59, 130, 246, 0.18)',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -163,18 +188,84 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                     >
                       <Icon name={descriptor.icon} size={18} />
                     </div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <p style={{
-                        margin: '0 0 4px 0',
-                        fontSize: '14px',
-                        color: 'var(--color-text)',
-                        fontWeight: notification.isRead ? 'normal' : '500'
-                      }}>
-                        {descriptor.getMessage(notification, userId)}
-                      </p>
-                      <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
-                        {new Date(notification.createdAt).toLocaleDateString()} a las {new Date(notification.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                      </span>
+
+                    <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                        <span
+                          style={{
+                            fontSize: '13px',
+                            fontWeight: notification.isRead ? 500 : 600,
+                            color: 'var(--color-text)',
+                          }}
+                        >
+                          {content.title}
+                        </span>
+                        {!notification.isRead && (
+                          <span
+                            aria-label="No leída"
+                            style={{
+                              width: '8px',
+                              height: '8px',
+                              borderRadius: '50%',
+                              background: 'var(--color-primary)',
+                              display: 'inline-block',
+                            }}
+                          />
+                        )}
+                      </div>
+
+                      {content.description && (
+                        <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)', lineHeight: 1.4 }}>
+                          {content.description}
+                        </span>
+                      )}
+
+                      {content.primary && (
+                        <span
+                          style={{
+                            fontSize: '14px',
+                            fontWeight: 600,
+                            color: 'var(--color-text)',
+                            wordBreak: 'break-word',
+                          }}
+                        >
+                          {content.primary}
+                        </span>
+                      )}
+
+                      {content.secondary && (
+                        <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
+                          {content.secondary}
+                        </span>
+                      )}
+
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '8px',
+                          marginTop: '2px',
+                          flexWrap: 'wrap',
+                        }}
+                      >
+                        {content.status && (
+                          <span
+                            style={{
+                              fontSize: '11px',
+                              fontWeight: 600,
+                              padding: '2px 8px',
+                              borderRadius: '999px',
+                              letterSpacing: '0.02em',
+                              ...STATUS_TONE_STYLES[content.status.tone],
+                            }}
+                          >
+                            {content.status.label}
+                          </span>
+                        )}
+                        <span style={{ fontSize: '11px', color: 'var(--color-text-tertiary, #94A3B8)' }}>
+                          {formatRelativeTime(new Date(notification.createdAt))}
+                        </span>
+                      </div>
                     </div>
                   </div>
                 );
@@ -190,8 +281,8 @@ export function NotificationBell({ userId }: NotificationBellProps) {
             position: absolute;
             top: calc(100% + 8px);
             right: 0;
-            width: 320px;
-            max-height: 400px;
+            width: 360px;
+            max-height: 480px;
             background: var(--color-surface);
             border: 1px solid var(--color-border);
             border-radius: var(--radius-lg);
@@ -210,7 +301,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
               left: 0;
               right: 0;
               width: 100%;
-              max-height: 70vh;
+              max-height: 75vh;
               border-radius: var(--radius-lg) var(--radius-lg) 0 0;
             }
           }

--- a/src/presentation/modules/notifications/components/NotificationBell.tsx
+++ b/src/presentation/modules/notifications/components/NotificationBell.tsx
@@ -1,26 +1,13 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useNotificationsList, useMarkNotificationRead, useMarkAllNotificationsRead } from '@/presentation/modules/notifications/hooks/useNotifications';
+import { describeNotification } from '@/presentation/modules/notifications/registry/notificationRegistry';
 import WcButtonIcon from '@/presentation/modules/shared/components/ui/webcomponents/Buttons/wcButtonIcon';
+import { Icon } from '@/presentation/modules/shared/components/Sidebar/icons/Icon';
 import type { Notification } from '@/domain/modules/notifications/models/Notification';
 
 interface NotificationBellProps {
   userId: string | undefined;
-}
-
-function getNotificationMessage(notification: Notification, currentUserId: string | undefined): string {
-  const isSelf = currentUserId && notification.actorId === currentUserId;
-
-  switch (notification.type) {
-    case 'NEW_USER':
-      return isSelf
-        ? 'Has registrado un nuevo usuario exitosamente'
-        : `${notification.actorName || 'Un administrador'} ha registrado un nuevo usuario`;
-    default:
-      return isSelf
-        ? 'Has realizado una acci\u00f3n en el sistema'
-        : `${notification.actorName || 'Alguien'} ha realizado una acci\u00f3n`;
-  }
 }
 
 export function NotificationBell({ userId }: NotificationBellProps) {
@@ -29,7 +16,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
   const navigate = useNavigate();
 
   const { data: notifications = [], isLoading } = useNotificationsList(userId);
-  const { mutate: markAsRead } = useMarkNotificationRead();
+  const { mutate: markAsRead } = useMarkNotificationRead(userId);
   const { mutate: markAllAsRead, isPending: isMarkingAll } = useMarkAllNotificationsRead(userId);
 
   const unreadCount = notifications.filter(n => !n.isRead).length;
@@ -49,8 +36,10 @@ export function NotificationBell({ userId }: NotificationBellProps) {
       markAsRead(notification.id);
     }
 
-    if (notification.type === 'NEW_USER') {
-      navigate('/users');
+    const descriptor = describeNotification(notification.type);
+    const route = descriptor.getRoute?.(notification);
+    if (route) {
+      navigate(route);
     }
     setIsOpen(false);
   };
@@ -136,37 +125,60 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                 No tienes notificaciones
               </div>
             ) : (
-              notifications.map((notification) => (
-                <div
-                  key={notification.id}
-                  onClick={() => handleNotificationClick(notification)}
-                  style={{
-                    padding: '12px 16px',
-                    borderBottom: '1px solid var(--color-border)',
-                    background: notification.isRead ? 'transparent' : 'var(--color-primary-light)',
-                    cursor: 'pointer',
-                    transition: 'background 0.2s ease',
-                  }}
-                  onMouseEnter={(e) => {
-                    if (notification.isRead) e.currentTarget.style.background = 'var(--color-surface-hover)';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = notification.isRead ? 'transparent' : 'var(--color-primary-light)';
-                  }}
-                >
-                  <p style={{ 
-                    margin: '0 0 4px 0', 
-                    fontSize: '14px', 
-                    color: 'var(--color-text)',
-                    fontWeight: notification.isRead ? 'normal' : '500' 
-                  }}>
-                    {getNotificationMessage(notification, userId)}
-                  </p>
-                  <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
-                    {new Date(notification.createdAt).toLocaleDateString()} a las {new Date(notification.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                  </span>
-                </div>
-              ))
+              notifications.map((notification) => {
+                const descriptor = describeNotification(notification.type);
+                return (
+                  <div
+                    key={notification.id}
+                    onClick={() => handleNotificationClick(notification)}
+                    style={{
+                      padding: '12px 16px',
+                      borderBottom: '1px solid var(--color-border)',
+                      background: notification.isRead ? 'transparent' : 'var(--color-primary-light)',
+                      cursor: 'pointer',
+                      transition: 'background 0.2s ease',
+                      display: 'flex',
+                      gap: '12px',
+                      alignItems: 'flex-start',
+                    }}
+                    onMouseEnter={(e) => {
+                      if (notification.isRead) e.currentTarget.style.background = 'var(--color-surface-hover)';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.background = notification.isRead ? 'transparent' : 'var(--color-primary-light)';
+                    }}
+                  >
+                    <div
+                      style={{
+                        flex: '0 0 auto',
+                        width: '32px',
+                        height: '32px',
+                        borderRadius: '50%',
+                        background: 'var(--color-surface-hover)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: 'var(--color-primary)',
+                      }}
+                    >
+                      <Icon name={descriptor.icon} size={18} />
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <p style={{
+                        margin: '0 0 4px 0',
+                        fontSize: '14px',
+                        color: 'var(--color-text)',
+                        fontWeight: notification.isRead ? 'normal' : '500'
+                      }}>
+                        {descriptor.getMessage(notification, userId)}
+                      </p>
+                      <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
+                        {new Date(notification.createdAt).toLocaleDateString()} a las {new Date(notification.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })
             )}
           </div>
         </div>

--- a/src/presentation/modules/notifications/hooks/useNotificationSubscription.ts
+++ b/src/presentation/modules/notifications/hooks/useNotificationSubscription.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/infrastructure/core/supabaseClient';
 import { useToastStore } from '@/presentation/modules/shared/components/Toaster';
 import { NOTIFICATIONS_QUERY_KEY } from './useNotifications';
-import { describeNotification } from '@/presentation/modules/notifications/registry/notificationRegistry';
+import { describeNotification, notificationToastMessage } from '@/presentation/modules/notifications/registry/notificationRegistry';
 import type { Notification } from '@/domain/modules/notifications/models/Notification';
 
 export function useNotificationSubscription(userId: string | undefined | null) {
@@ -46,9 +46,10 @@ export function useNotificationSubscription(userId: string | undefined | null) {
           queryClient.invalidateQueries({ queryKey: [...NOTIFICATIONS_QUERY_KEY, userId] });
 
           const descriptor = describeNotification(newNotification.type);
+          const content = descriptor.getContent(newNotification, userId);
           addToast({
             type: descriptor.toastVariant,
-            message: descriptor.getMessage(newNotification, userId),
+            message: notificationToastMessage(content),
             duration: 4000,
           });
         }

--- a/src/presentation/modules/notifications/hooks/useNotificationSubscription.ts
+++ b/src/presentation/modules/notifications/hooks/useNotificationSubscription.ts
@@ -3,16 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/infrastructure/core/supabaseClient';
 import { useToastStore } from '@/presentation/modules/shared/components/Toaster';
 import { NOTIFICATIONS_QUERY_KEY } from './useNotifications';
+import { describeNotification } from '@/presentation/modules/notifications/registry/notificationRegistry';
 import type { Notification } from '@/domain/modules/notifications/models/Notification';
-
-function getToastDetailsForType(notification: Notification): { title: string; type: 'success' | 'info' | 'warning' } {
-  switch (notification.type) {
-    case 'NEW_USER':
-      return { title: 'Nuevo usuario registrado en el sistema.', type: 'info' };
-    default:
-      return { title: 'Nueva notificación.', type: 'info' };
-  }
-}
 
 export function useNotificationSubscription(userId: string | undefined | null) {
   const queryClient = useQueryClient();
@@ -33,7 +25,7 @@ export function useNotificationSubscription(userId: string | undefined | null) {
         },
         (payload) => {
           const newNotificationTemp = payload.new;
-          
+
           const newNotification: Notification = {
             id: newNotificationTemp.id,
             recipientId: newNotificationTemp.recipient_id,
@@ -47,10 +39,10 @@ export function useNotificationSubscription(userId: string | undefined | null) {
 
           queryClient.invalidateQueries({ queryKey: [...NOTIFICATIONS_QUERY_KEY, userId] });
 
-          const toastDetails = getToastDetailsForType(newNotification);
+          const descriptor = describeNotification(newNotification.type);
           addToast({
-            type: toastDetails.type,
-            message: toastDetails.title,
+            type: descriptor.toastVariant,
+            message: descriptor.toastTitle,
             duration: 4000,
           });
         }

--- a/src/presentation/modules/notifications/hooks/useNotificationSubscription.ts
+++ b/src/presentation/modules/notifications/hooks/useNotificationSubscription.ts
@@ -25,14 +25,20 @@ export function useNotificationSubscription(userId: string | undefined | null) {
         },
         (payload) => {
           const newNotificationTemp = payload.new;
+          const metadata = (newNotificationTemp.metadata ?? {}) as Notification['metadata'];
+          const metadataActorName =
+            typeof metadata.actorName === 'string' && metadata.actorName.trim().length > 0
+              ? metadata.actorName
+              : null;
 
           const newNotification: Notification = {
             id: newNotificationTemp.id,
             recipientId: newNotificationTemp.recipient_id,
             actorId: newNotificationTemp.actor_id,
-            actorName: null,
+            actorName: metadataActorName,
             type: newNotificationTemp.type,
             entityId: newNotificationTemp.entity_id,
+            metadata,
             isRead: newNotificationTemp.is_read,
             createdAt: new Date(newNotificationTemp.created_at),
           };
@@ -42,7 +48,7 @@ export function useNotificationSubscription(userId: string | undefined | null) {
           const descriptor = describeNotification(newNotification.type);
           addToast({
             type: descriptor.toastVariant,
-            message: descriptor.toastTitle,
+            message: descriptor.getMessage(newNotification, userId),
             duration: 4000,
           });
         }

--- a/src/presentation/modules/notifications/hooks/useNotifications.ts
+++ b/src/presentation/modules/notifications/hooks/useNotifications.ts
@@ -16,20 +16,22 @@ export function useNotificationsList(userId: string | undefined) {
   });
 }
 
-export function useMarkNotificationRead() {
+export function useMarkNotificationRead(userId: string | undefined) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (notificationId: string) => notificationService.markAsRead(notificationId),
     onSuccess: (_, notificationId) => {
-      queryClient.setQueryData(
-        NOTIFICATIONS_QUERY_KEY,
-        (oldData: Notification[] | undefined) => {
-          if (!oldData) return oldData;
-          return oldData.map(n => n.id === notificationId ? { ...n, isRead: true } : n);
-        }
-      );
-      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY });
+      if (userId) {
+        queryClient.setQueryData(
+          [...NOTIFICATIONS_QUERY_KEY, userId],
+          (oldData: Notification[] | undefined) => {
+            if (!oldData) return oldData;
+            return oldData.map(n => n.id === notificationId ? { ...n, isRead: true } : n);
+          }
+        );
+      }
+      queryClient.invalidateQueries({ queryKey: [...NOTIFICATIONS_QUERY_KEY, userId] });
     },
   });
 }

--- a/src/presentation/modules/notifications/registry/notificationRegistry.ts
+++ b/src/presentation/modules/notifications/registry/notificationRegistry.ts
@@ -97,6 +97,8 @@ const NOTIFICATION_REGISTRY: Record<string, NotificationDescriptor> = {
       };
     },
     getRoute: (n) => {
+      const patientId = asString(n.metadata.patientId) ?? asString(n.entityId);
+      if (patientId) return `/pacientes?openId=${patientId}`;
       const idNumber = asString(n.metadata.patientIdNumber);
       return idNumber ? `/pacientes?search=${encodeURIComponent(idNumber)}` : '/pacientes';
     },
@@ -120,8 +122,7 @@ const NOTIFICATION_REGISTRY: Record<string, NotificationDescriptor> = {
     getRoute: (n) => {
       const patientId = asString(n.metadata.patientId);
       if (patientId) return `/pacientes/${patientId}/historia`;
-      const idNumber = asString(n.metadata.patientIdNumber);
-      return idNumber ? `/historias-clinicas?search=${encodeURIComponent(idNumber)}` : '/historias-clinicas';
+      return '/historias-clinicas';
     },
   },
 
@@ -148,8 +149,7 @@ const NOTIFICATION_REGISTRY: Record<string, NotificationDescriptor> = {
       if (patientId && evolutionId) {
         return `/pacientes/${patientId}/historia/evoluciones/${evolutionId}`;
       }
-      const idNumber = asString(n.metadata.patientIdNumber);
-      return idNumber ? `/evoluciones?search=${encodeURIComponent(idNumber)}` : '/evoluciones';
+      return '/evoluciones';
     },
   },
 

--- a/src/presentation/modules/notifications/registry/notificationRegistry.ts
+++ b/src/presentation/modules/notifications/registry/notificationRegistry.ts
@@ -1,20 +1,35 @@
 import type { Notification, NotificationType } from '@/domain/modules/notifications/models/Notification';
 
 export type NotificationToastVariant = 'success' | 'info' | 'warning';
+export type NotificationStatusTone = 'info' | 'success' | 'warning' | 'neutral';
+
+export interface NotificationStatusBadge {
+  label: string;
+  tone: NotificationStatusTone;
+}
+
+export interface NotificationContent {
+  title: string;
+  description?: string | null;
+  primary?: string | null;
+  secondary?: string | null;
+  status?: NotificationStatusBadge | null;
+}
 
 export interface NotificationDescriptor {
   icon: string;
   toastVariant: NotificationToastVariant;
-  toastTitle: string;
-  getMessage: (notification: Notification, currentUserId?: string | null) => string;
+  getContent: (notification: Notification, currentUserId?: string | null) => NotificationContent;
   getRoute?: (notification: Notification) => string | undefined;
 }
 
 const fallbackDescriptor: NotificationDescriptor = {
   icon: 'icon-bell',
   toastVariant: 'info',
-  toastTitle: 'Nueva notificación',
-  getMessage: () => 'Tienes una nueva notificación en el sistema.',
+  getContent: () => ({
+    title: 'Nueva notificación',
+    description: 'Tienes una nueva notificación en el sistema.',
+  }),
 };
 
 const isSelfActor = (notification: Notification, currentUserId?: string | null) =>
@@ -30,104 +45,132 @@ function actorLabel(notification: Notification, fallbackName = 'Otro usuario'): 
   return asString(notification.metadata.actorName) ?? asString(notification.actorName) ?? fallbackName;
 }
 
-function patientLabel(notification: Notification): string | null {
-  const name = asString(notification.metadata.patientName);
+function evolutionStatusTone(status: string): NotificationStatusTone {
+  switch (status) {
+    case 'ABIERTA':    return 'info';
+    case 'EN_PROCESO': return 'warning';
+    case 'CERRADA':    return 'success';
+    default:           return 'neutral';
+  }
+}
+
+function patientIdNumberLabel(notification: Notification): string | null {
   const idNumber = asString(notification.metadata.patientIdNumber);
-  if (name && idNumber) return `${name} (${idNumber})`;
-  return name ?? idNumber;
+  return idNumber ? `CI / ID: ${idNumber}` : null;
 }
 
 const NOTIFICATION_REGISTRY: Record<string, NotificationDescriptor> = {
   NEW_USER: {
     icon: 'icon-user-plus',
     toastVariant: 'info',
-    toastTitle: 'Nuevo usuario registrado',
-    getMessage: (n, uid) => {
+    getContent: (n, uid) => {
       const subject = asString(n.metadata.subjectName);
       const role = asString(n.metadata.subjectRole);
-      const roleSuffix = role ? ` con el rol ${role}` : '';
-      if (isSelfActor(n, uid)) {
-        return subject
-          ? `Has registrado a ${subject}${roleSuffix}.`
-          : 'Has registrado un nuevo usuario.';
-      }
-      const actor = actorLabel(n, 'Un administrador');
-      return subject
-        ? `${actor} registró a ${subject}${roleSuffix}.`
-        : `${actor} registró un nuevo usuario.`;
+      const email = asString(n.metadata.subjectEmail);
+      const secondaryParts = [role, email].filter((part): part is string => Boolean(part));
+      const description = isSelfActor(n, uid)
+        ? 'Registraste un nuevo usuario:'
+        : `${actorLabel(n, 'Un administrador')} registró un nuevo usuario:`;
+      return {
+        title: 'Nuevo usuario registrado',
+        description: subject ? description : null,
+        primary: subject ?? (isSelfActor(n, uid) ? 'Has registrado un nuevo usuario.' : `${actorLabel(n, 'Un administrador')} registró un nuevo usuario.`),
+        secondary: secondaryParts.length > 0 ? secondaryParts.join(' • ') : null,
+      };
     },
     getRoute: () => '/admin/users',
   },
+
   NEW_PATIENT: {
     icon: 'icon-patient',
     toastVariant: 'success',
-    toastTitle: 'Nuevo paciente registrado',
-    getMessage: (n, uid) => {
-      const patient = patientLabel(n);
-      if (isSelfActor(n, uid)) {
-        return patient
-          ? `Has registrado al paciente ${patient}.`
-          : 'Has registrado un nuevo paciente.';
-      }
-      const actor = actorLabel(n);
-      return patient
-        ? `${actor} registró al paciente ${patient}.`
-        : `${actor} registró un nuevo paciente.`;
+    getContent: (n, uid) => {
+      const patientName = asString(n.metadata.patientName);
+      const description = isSelfActor(n, uid)
+        ? 'Registraste un nuevo paciente:'
+        : `${actorLabel(n)} registró un nuevo paciente:`;
+      return {
+        title: 'Nuevo paciente registrado',
+        description: patientName ? description : null,
+        primary: patientName ?? (isSelfActor(n, uid) ? 'Has registrado un nuevo paciente.' : `${actorLabel(n)} registró un nuevo paciente.`),
+        secondary: patientIdNumberLabel(n),
+      };
     },
-    getRoute: () => '/pacientes',
+    getRoute: (n) => {
+      const idNumber = asString(n.metadata.patientIdNumber);
+      return idNumber ? `/pacientes?search=${encodeURIComponent(idNumber)}` : '/pacientes';
+    },
   },
+
   NEW_MEDICAL_RECORD: {
     icon: 'icon-clinical-history',
     toastVariant: 'success',
-    toastTitle: 'Nueva historia clínica',
-    getMessage: (n, uid) => {
-      const patient = patientLabel(n);
-      if (isSelfActor(n, uid)) {
-        return patient
-          ? `Has creado la historia clínica de ${patient}.`
-          : 'Has creado una nueva historia clínica.';
-      }
-      const actor = actorLabel(n);
-      return patient
-        ? `${actor} creó la historia clínica de ${patient}.`
-        : `${actor} creó una nueva historia clínica.`;
+    getContent: (n, uid) => {
+      const patientName = asString(n.metadata.patientName);
+      const description = isSelfActor(n, uid)
+        ? 'Creaste una nueva historia clínica para:'
+        : `${actorLabel(n)} creó una nueva historia clínica para:`;
+      return {
+        title: 'Nueva historia clínica',
+        description: patientName ? description : null,
+        primary: patientName ?? (isSelfActor(n, uid) ? 'Has creado una nueva historia clínica.' : `${actorLabel(n)} creó una nueva historia clínica.`),
+        secondary: patientIdNumberLabel(n),
+      };
     },
-    getRoute: () => '/historias-clinicas',
+    getRoute: (n) => {
+      const patientId = asString(n.metadata.patientId);
+      if (patientId) return `/pacientes/${patientId}/historia`;
+      const idNumber = asString(n.metadata.patientIdNumber);
+      return idNumber ? `/historias-clinicas?search=${encodeURIComponent(idNumber)}` : '/historias-clinicas';
+    },
   },
+
   NEW_EVOLUTION: {
     icon: 'icon-medical-evolution',
     toastVariant: 'success',
-    toastTitle: 'Nueva evolución médica',
-    getMessage: (n, uid) => {
-      const patient = patientLabel(n);
+    getContent: (n, uid) => {
+      const patientName = asString(n.metadata.patientName);
       const status = asString(n.metadata.evolutionStatus);
-      const statusSuffix = status ? ` (${status})` : '';
-      if (isSelfActor(n, uid)) {
-        return patient
-          ? `Has registrado una evolución para ${patient}${statusSuffix}.`
-          : 'Has registrado una nueva evolución médica.';
-      }
-      const actor = actorLabel(n);
-      return patient
-        ? `${actor} registró una evolución para ${patient}${statusSuffix}.`
-        : `${actor} registró una nueva evolución médica.`;
+      const description = isSelfActor(n, uid)
+        ? 'Registraste una nueva evolución para:'
+        : `${actorLabel(n)} registró una nueva evolución para:`;
+      return {
+        title: 'Nueva evolución médica',
+        description: patientName ? description : null,
+        primary: patientName ?? (isSelfActor(n, uid) ? 'Has registrado una nueva evolución.' : `${actorLabel(n)} registró una nueva evolución.`),
+        secondary: patientIdNumberLabel(n),
+        status: status ? { label: status, tone: evolutionStatusTone(status) } : null,
+      };
     },
-    getRoute: () => '/evoluciones',
+    getRoute: (n) => {
+      const patientId = asString(n.metadata.patientId);
+      const evolutionId = asString(n.entityId);
+      if (patientId && evolutionId) {
+        return `/pacientes/${patientId}/historia/evoluciones/${evolutionId}`;
+      }
+      const idNumber = asString(n.metadata.patientIdNumber);
+      return idNumber ? `/evoluciones?search=${encodeURIComponent(idNumber)}` : '/evoluciones';
+    },
   },
+
   TASK_ASSIGNED: {
     icon: 'icon-user-voice',
     toastVariant: 'info',
-    toastTitle: 'Tarea asignada',
-    getMessage: (n, uid) =>
-      isSelfActor(n, uid)
+    getContent: (n, uid) => ({
+      title: 'Tarea asignada',
+      primary: isSelfActor(n, uid)
         ? 'Te has asignado una nueva tarea.'
         : `${actorLabel(n)} te asignó una nueva tarea.`,
+    }),
   },
+
   SYSTEM_ALERT: {
     icon: 'icon-alert-triangle',
     toastVariant: 'warning',
-    toastTitle: 'Alerta del sistema',
-    getMessage: () => 'Se ha emitido una alerta del sistema. Revísala cuanto antes.',
+    getContent: () => ({
+      title: 'Alerta del sistema',
+      description: 'Se ha emitido una alerta del sistema. Revísala cuanto antes.',
+    }),
   },
 };
 
@@ -137,4 +180,10 @@ export function describeNotification(type: NotificationType): NotificationDescri
 
 export function registerNotificationDescriptor(type: string, descriptor: NotificationDescriptor): void {
   NOTIFICATION_REGISTRY[type] = descriptor;
+}
+
+export function notificationToastMessage(content: NotificationContent): string {
+  const parts = [content.title];
+  if (content.primary) parts.push(content.primary);
+  return parts.join(' — ');
 }

--- a/src/presentation/modules/notifications/registry/notificationRegistry.ts
+++ b/src/presentation/modules/notifications/registry/notificationRegistry.ts
@@ -20,48 +20,98 @@ const fallbackDescriptor: NotificationDescriptor = {
 const isSelfActor = (notification: Notification, currentUserId?: string | null) =>
   Boolean(currentUserId) && notification.actorId === currentUserId;
 
-const actorLabel = (notification: Notification, fallbackName = 'Otro usuario') =>
-  notification.actorName?.trim() || fallbackName;
+function asString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function actorLabel(notification: Notification, fallbackName = 'Otro usuario'): string {
+  return asString(notification.metadata.actorName) ?? asString(notification.actorName) ?? fallbackName;
+}
+
+function patientLabel(notification: Notification): string | null {
+  const name = asString(notification.metadata.patientName);
+  const idNumber = asString(notification.metadata.patientIdNumber);
+  if (name && idNumber) return `${name} (${idNumber})`;
+  return name ?? idNumber;
+}
 
 const NOTIFICATION_REGISTRY: Record<string, NotificationDescriptor> = {
   NEW_USER: {
     icon: 'icon-user-plus',
     toastVariant: 'info',
     toastTitle: 'Nuevo usuario registrado',
-    getMessage: (n, uid) =>
-      isSelfActor(n, uid)
-        ? 'Has registrado un nuevo usuario en el sistema.'
-        : `${actorLabel(n, 'Un administrador')} registró un nuevo usuario.`,
+    getMessage: (n, uid) => {
+      const subject = asString(n.metadata.subjectName);
+      const role = asString(n.metadata.subjectRole);
+      const roleSuffix = role ? ` con el rol ${role}` : '';
+      if (isSelfActor(n, uid)) {
+        return subject
+          ? `Has registrado a ${subject}${roleSuffix}.`
+          : 'Has registrado un nuevo usuario.';
+      }
+      const actor = actorLabel(n, 'Un administrador');
+      return subject
+        ? `${actor} registró a ${subject}${roleSuffix}.`
+        : `${actor} registró un nuevo usuario.`;
+    },
     getRoute: () => '/admin/users',
   },
   NEW_PATIENT: {
     icon: 'icon-patient',
     toastVariant: 'success',
     toastTitle: 'Nuevo paciente registrado',
-    getMessage: (n, uid) =>
-      isSelfActor(n, uid)
-        ? 'Has registrado un nuevo paciente.'
-        : `${actorLabel(n)} registró un nuevo paciente.`,
+    getMessage: (n, uid) => {
+      const patient = patientLabel(n);
+      if (isSelfActor(n, uid)) {
+        return patient
+          ? `Has registrado al paciente ${patient}.`
+          : 'Has registrado un nuevo paciente.';
+      }
+      const actor = actorLabel(n);
+      return patient
+        ? `${actor} registró al paciente ${patient}.`
+        : `${actor} registró un nuevo paciente.`;
+    },
     getRoute: () => '/pacientes',
   },
   NEW_MEDICAL_RECORD: {
     icon: 'icon-clinical-history',
     toastVariant: 'success',
     toastTitle: 'Nueva historia clínica',
-    getMessage: (n, uid) =>
-      isSelfActor(n, uid)
-        ? 'Has creado una nueva historia clínica.'
-        : `${actorLabel(n)} creó una nueva historia clínica.`,
+    getMessage: (n, uid) => {
+      const patient = patientLabel(n);
+      if (isSelfActor(n, uid)) {
+        return patient
+          ? `Has creado la historia clínica de ${patient}.`
+          : 'Has creado una nueva historia clínica.';
+      }
+      const actor = actorLabel(n);
+      return patient
+        ? `${actor} creó la historia clínica de ${patient}.`
+        : `${actor} creó una nueva historia clínica.`;
+    },
     getRoute: () => '/historias-clinicas',
   },
   NEW_EVOLUTION: {
     icon: 'icon-medical-evolution',
     toastVariant: 'success',
     toastTitle: 'Nueva evolución médica',
-    getMessage: (n, uid) =>
-      isSelfActor(n, uid)
-        ? 'Has registrado una nueva evolución médica.'
-        : `${actorLabel(n)} registró una nueva evolución médica.`,
+    getMessage: (n, uid) => {
+      const patient = patientLabel(n);
+      const status = asString(n.metadata.evolutionStatus);
+      const statusSuffix = status ? ` (${status})` : '';
+      if (isSelfActor(n, uid)) {
+        return patient
+          ? `Has registrado una evolución para ${patient}${statusSuffix}.`
+          : 'Has registrado una nueva evolución médica.';
+      }
+      const actor = actorLabel(n);
+      return patient
+        ? `${actor} registró una evolución para ${patient}${statusSuffix}.`
+        : `${actor} registró una nueva evolución médica.`;
+    },
     getRoute: () => '/evoluciones',
   },
   TASK_ASSIGNED: {

--- a/src/presentation/modules/notifications/registry/notificationRegistry.ts
+++ b/src/presentation/modules/notifications/registry/notificationRegistry.ts
@@ -1,0 +1,90 @@
+import type { Notification, NotificationType } from '@/domain/modules/notifications/models/Notification';
+
+export type NotificationToastVariant = 'success' | 'info' | 'warning';
+
+export interface NotificationDescriptor {
+  icon: string;
+  toastVariant: NotificationToastVariant;
+  toastTitle: string;
+  getMessage: (notification: Notification, currentUserId?: string | null) => string;
+  getRoute?: (notification: Notification) => string | undefined;
+}
+
+const fallbackDescriptor: NotificationDescriptor = {
+  icon: 'icon-bell',
+  toastVariant: 'info',
+  toastTitle: 'Nueva notificación',
+  getMessage: () => 'Tienes una nueva notificación en el sistema.',
+};
+
+const isSelfActor = (notification: Notification, currentUserId?: string | null) =>
+  Boolean(currentUserId) && notification.actorId === currentUserId;
+
+const actorLabel = (notification: Notification, fallbackName = 'Otro usuario') =>
+  notification.actorName?.trim() || fallbackName;
+
+const NOTIFICATION_REGISTRY: Record<string, NotificationDescriptor> = {
+  NEW_USER: {
+    icon: 'icon-user-plus',
+    toastVariant: 'info',
+    toastTitle: 'Nuevo usuario registrado',
+    getMessage: (n, uid) =>
+      isSelfActor(n, uid)
+        ? 'Has registrado un nuevo usuario en el sistema.'
+        : `${actorLabel(n, 'Un administrador')} registró un nuevo usuario.`,
+    getRoute: () => '/admin/users',
+  },
+  NEW_PATIENT: {
+    icon: 'icon-patient',
+    toastVariant: 'success',
+    toastTitle: 'Nuevo paciente registrado',
+    getMessage: (n, uid) =>
+      isSelfActor(n, uid)
+        ? 'Has registrado un nuevo paciente.'
+        : `${actorLabel(n)} registró un nuevo paciente.`,
+    getRoute: () => '/pacientes',
+  },
+  NEW_MEDICAL_RECORD: {
+    icon: 'icon-clinical-history',
+    toastVariant: 'success',
+    toastTitle: 'Nueva historia clínica',
+    getMessage: (n, uid) =>
+      isSelfActor(n, uid)
+        ? 'Has creado una nueva historia clínica.'
+        : `${actorLabel(n)} creó una nueva historia clínica.`,
+    getRoute: () => '/historias-clinicas',
+  },
+  NEW_EVOLUTION: {
+    icon: 'icon-medical-evolution',
+    toastVariant: 'success',
+    toastTitle: 'Nueva evolución médica',
+    getMessage: (n, uid) =>
+      isSelfActor(n, uid)
+        ? 'Has registrado una nueva evolución médica.'
+        : `${actorLabel(n)} registró una nueva evolución médica.`,
+    getRoute: () => '/evoluciones',
+  },
+  TASK_ASSIGNED: {
+    icon: 'icon-user-voice',
+    toastVariant: 'info',
+    toastTitle: 'Tarea asignada',
+    getMessage: (n, uid) =>
+      isSelfActor(n, uid)
+        ? 'Te has asignado una nueva tarea.'
+        : `${actorLabel(n)} te asignó una nueva tarea.`,
+  },
+  SYSTEM_ALERT: {
+    icon: 'icon-alert-triangle',
+    toastVariant: 'warning',
+    toastTitle: 'Alerta del sistema',
+    getMessage: () => 'Se ha emitido una alerta del sistema. Revísala cuanto antes.',
+  },
+};
+
+export function describeNotification(type: NotificationType): NotificationDescriptor {
+  return NOTIFICATION_REGISTRY[type] ?? fallbackDescriptor;
+}
+
+export function registerNotificationDescriptor(type: string, descriptor: NotificationDescriptor): void {
+  NOTIFICATION_REGISTRY[type] = descriptor;
+}

--- a/src/presentation/modules/patient/components/Patients/PatientSearchFilters.tsx
+++ b/src/presentation/modules/patient/components/Patients/PatientSearchFilters.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { usePatientStore } from "@/presentation/modules/patient/stores/usePatientStore";
 import { useToastStore } from "@/presentation/modules/shared/components/Toaster";
 import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
@@ -16,12 +16,19 @@ const DEFAULT_FILTERS: PatientQuickFilterState = {
 };
 
 export function PatientSearchFilters() {
-  const { setPatientFilters, hasSearched, setHasSearched, resetPatientFilters } = usePatientStore();
+  const { setPatientFilters, hasSearched, setHasSearched, resetPatientFilters, patientFilters } = usePatientStore();
   const { addToast } = useToastStore();
 
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(
+    () => patientFilters.idNumber || patientFilters.search || ""
+  );
   const [isFilterPopoverOpen, setIsFilterPopoverOpen] = useState(false);
   const [localFilters, setLocalFilters] = useState<PatientQuickFilterState>(DEFAULT_FILTERS);
+
+  useEffect(() => {
+    const storeValue = patientFilters.idNumber || patientFilters.search || "";
+    setSearchQuery(storeValue);
+  }, [patientFilters.idNumber, patientFilters.search]);
 
   const activeFiltersCount = useMemo(() => {
     let count = 0;

--- a/src/presentation/modules/patient/pages/PatientsPage.tsx
+++ b/src/presentation/modules/patient/pages/PatientsPage.tsx
@@ -18,29 +18,48 @@ export function PatientsPage() {
     selectedPatientId,
     setPatientFilters,
     setHasSearched,
+    setSelectedPatientId,
   } = usePatientStore();
 
   const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
+    const openIdFromUrl = searchParams.get("openId");
     const queryFromUrl = searchParams.get("search");
-    if (!queryFromUrl) return;
 
-    const cleanQuery = queryFromUrl.trim();
-    if (cleanQuery.length === 0) return;
+    if (!openIdFromUrl && !queryFromUrl) return;
 
-    const isIdNumber = /^\d+$/.test(cleanQuery);
-    setPatientFilters({
-      idNumber: isIdNumber ? cleanQuery : undefined,
-      search: !isIdNumber ? cleanQuery : undefined,
-      page: 1,
-    });
-    setHasSearched(true);
-
+    let mutated = false;
     const nextParams = new URLSearchParams(searchParams);
-    nextParams.delete("search");
-    setSearchParams(nextParams, { replace: true });
-  }, [searchParams, setPatientFilters, setHasSearched, setSearchParams]);
+
+    if (openIdFromUrl) {
+      const cleanId = openIdFromUrl.trim();
+      if (cleanId.length > 0) {
+        setSelectedPatientId(cleanId);
+        nextParams.delete("openId");
+        mutated = true;
+      }
+    }
+
+    if (queryFromUrl) {
+      const cleanQuery = queryFromUrl.trim();
+      if (cleanQuery.length > 0) {
+        const isIdNumber = /^\d+$/.test(cleanQuery);
+        setPatientFilters({
+          idNumber: isIdNumber ? cleanQuery : undefined,
+          search: !isIdNumber ? cleanQuery : undefined,
+          page: 1,
+        });
+        setHasSearched(true);
+        nextParams.delete("search");
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [searchParams, setPatientFilters, setHasSearched, setSelectedPatientId, setSearchParams]);
 
   const {
     data: patientsResult,

--- a/src/presentation/modules/patient/pages/PatientsPage.tsx
+++ b/src/presentation/modules/patient/pages/PatientsPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 import { usePatientStore } from "@/presentation/modules/patient/stores/usePatientStore";
 import { usePatients } from "@/presentation/modules/patient/hooks/usePatients";
 import { Icon } from "@/presentation/modules/shared/components/Sidebar/icons/Icon";
@@ -14,7 +16,31 @@ export function PatientsPage() {
     patientFilters,
     hasSearched,
     selectedPatientId,
+    setPatientFilters,
+    setHasSearched,
   } = usePatientStore();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    const queryFromUrl = searchParams.get("search");
+    if (!queryFromUrl) return;
+
+    const cleanQuery = queryFromUrl.trim();
+    if (cleanQuery.length === 0) return;
+
+    const isIdNumber = /^\d+$/.test(cleanQuery);
+    setPatientFilters({
+      idNumber: isIdNumber ? cleanQuery : undefined,
+      search: !isIdNumber ? cleanQuery : undefined,
+      page: 1,
+    });
+    setHasSearched(true);
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("search");
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setPatientFilters, setHasSearched, setSearchParams]);
 
   const {
     data: patientsResult,


### PR DESCRIPTION
#### Resumen

Reconstruye y amplía el módulo de notificaciones in-app. Antes solo funcionaba para `NEW_USER` y mostraba a usuarios no-admin un mensaje genérico ("Otro usuario...") porque el cliente intentaba resolver el nombre del actor a través de un `JOIN` a `profiles` que estaba bloqueado por RLS. Esta rama:

1. Cubre las tres acciones clínicas faltantes: nuevo paciente, nueva historia  clínica y nueva evolución médica.
2. Diseña una arquitectura escalable basada en un **registry centralizado** donde  agregar un nuevo tipo de notificación cuesta una entrada de objeto + una migración SQL.
3. Persiste el contexto necesario (`metadata JSONB`) en la propia notificación para no depender de queries adicionales bloqueadas por RLS.
4. Rediseña la tarjeta del popover en formato multilínea con título, descripción, paciente destacado, CI/ID, estado y timestamp relativo.
5. Implementa **deep-links reales** al hacer clic: el paciente abre el drawer con  su ficha, la historia clínica abre la HC del paciente y la evolución abre directamente el workspace de esa evolución. 
6. Integra los cambios recientes de `develop` (identificación flexible con IDs temporales HCI) y adapta las rutas para que funcionen tanto con cédula como  con identificadores temporales.


#### Tipos de notificación soportados

| Tipo                 | Audiencia              | Icono                    | Deep-link al hacer clic                                                       |
|----------------------|------------------------|--------------------------|-------------------------------------------------------------------------------|
| `NEW_USER`           | Solo admins activos    | `icon-user-plus`         | `/admin/users`                                                                |
| `NEW_PATIENT`        | Todos los activos      | `icon-patient`           | `/pacientes?openId=<patientId>` (abre el drawer con la ficha)                 |
| `NEW_MEDICAL_RECORD` | Todos los activos      | `icon-clinical-history`  | `/pacientes/<patientId>/historia`                                             |
| `NEW_EVOLUTION`      | Todos los activos      | `icon-medical-evolution` | `/pacientes/<patientId>/historia/evoluciones/<evolutionId>` (workspace)       |

El actor siempre se excluye de su propio broadcast.

#### Cambios por capa

##### Domain (`src/domain/modules/notifications`)
- `Notification` ahora incluye `metadata: NotificationMetadata`.
- `KnownNotificationType` enumera los 6 tipos canónicos; `NotificationType` queda
  abierto para extensiones.
- `NotificationMetadata` tipa los campos populares (`actorName`, `patientId`,
  `patientName`, `patientIdNumber`, `evolutionStatus`, `subjectName/Email/Role`).

##### Infrastructure (`src/infrastructure/modules/notifications`)
- `SupabaseNotificationRepository`:
  - Lee `metadata` directamente de la fila.
  - Deriva `actorName` desde `metadata.actorName`.
  - **Elimina** el segundo `SELECT` contra `profiles` que rompía para no-admins.

##### Presentation (`src/presentation/modules/notifications`)
- **Nuevo** `registry/notificationRegistry.ts`:
  - Tipo `NotificationDescriptor` con `icon`, `toastVariant`, `getContent`,
    `getRoute`.
  - `NotificationContent` estructurado: `title`, `description`, `primary`,
    `secondary`, `status`.
  - Funciones `describeNotification`, `registerNotificationDescriptor` y
    `notificationToastMessage`.
- `NotificationBell.tsx`:
  - Popover más ancho (360px), tarjeta multilínea con icono tinted al estar sin
    leer, dot de no leída, badge de estado coloreado por tono y timestamp
    relativo ("hace 5 min", "hace 2 h", etc.).
- `useNotificationSubscription.ts`:
  - Construye la `Notification` completa desde el payload realtime incluyendo
    `metadata`, y emite el toast con el contenido estructurado.
- `useNotifications.ts`:
  - Fix de caché: `useMarkNotificationRead(userId)` ahora muta la queryKey
    correcta `[...NOTIFICATIONS_QUERY_KEY, userId]` (antes mutaba la base sin
    `userId` y la caché quedaba desincronizada).

##### Patient (`src/presentation/modules/patient`)
- `PatientsPage`:
  - Maneja `?openId=<uuid>` para abrir el drawer del paciente.
  - Maneja `?search=<value>` para hidratar el filtro del listado (numérico →
    `idNumber`, texto → `search`).
  - Limpia los query params tras aplicarlos.
- `PatientSearchFilters`:
  - El input visible se inicializa desde el filtro del store y se sincroniza
    cuando cambia por navegación externa, de modo que la UI siempre refleja la
    búsqueda activa.

##### Docs
- `AGENTS.md`:
  - Sección 7 (Notifications) documenta la nueva arquitectura, el contrato de
    `metadata` y la lista completa de migraciones SQL relevantes.
  - **Receta de 4 pasos** para agregar un nuevo tipo de notificación
    (cross-referenced desde "Convenciones para Añadir un Nuevo Módulo").
  - Se agregó al inicio del documento una visión general del sistema (módulos,
    rutas, integración Supabase, patrones convencionales y scripts).

#### Seguridad

- La tabla `notifications` mantiene la RLS existente: cada usuario solo lee sus
  propias notificaciones (`recipient_id = auth.uid()`).
- El enriquecimiento (`metadata`) se hace dentro de funciones `SECURITY DEFINER`
  en el servidor, por lo que pueden leer `profiles`, `patients` y
  `medical_records` sin exponer las tablas vía RLS al cliente.
- PII (nombre del paciente, número de cédula) viaja solo al destinatario
  legítimo de cada notificación, igual que antes con el JOIN a `profiles`.
- No se persiste PII en `localStorage` ni en stores de Zustand persistidos.

#### Compatibilidad con el merge de develop

Tras integrar `develop` (commits `7738bd2`..`17c24e5`), el módulo de pacientes
soporta identificadores temporales HCI (`HCI<YYYY>-XXXXXXXXX`). Esto cambió el
comportamiento del repositorio:

- El filtro `idNumber` ahora exige `id_number_type = 'cedula'`.
- El filtro `search` ya no busca en `id_number`.

Como consecuencia, navegar por `?search=<idNumber>` dejaba de funcionar para
pacientes con ID temporal. Las rutas se reescribieron para navegar por **UUID**
del paciente (presente en `entity_id` y en `metadata.patientId`), evitando el
problema por completo y siendo agnóstico del tipo de identificador.

#### Cómo probar

1. Aplicar las migraciones 26 → 30 del repo `supabase` (ver PR asociado).
2. En Supabase Dashboard > Database > Replication, confirmar que `notifications`
   está habilitado.
3. Con dos usuarios logueados (uno admin, otro no-admin):
   - Crear un paciente desde el admin → el no-admin debe recibir toast +
     incrementar contador, ver tarjeta con nombre del paciente y CI, y al hacer
     clic abrir el drawer con la ficha completa.
   - Crear una historia clínica → al hacer clic abrir `/pacientes/.../historia`.
   - Registrar una nueva evolución → al hacer clic abrir el workspace de la
     evolución con el formulario cargado.
   - Invitar un usuario nuevo → solo los admins reciben la notificación.
4. Repetir con un paciente que use ID temporal HCI: el drawer debe abrir
   igualmente porque navega por UUID, no por id_number.

#### Verificación automatizada

- `pnpm lint`: 0 errores. Los 5 warnings reportados son **preexistentes** en
  otros módulos (`evolution`, `medical-record`, `patient`).
- `pnpm exec tsc -b`: cero errores en archivos modificados. Los 9 errores TS
  reportados son **preexistentes en develop** (mismo set antes del merge).

#### Commits relevantes

```
7515dc8 fix(notifications): support patients with temporary HCI ids after develop merge
626307d Merge remote-tracking branch 'origin/develop' into feature/emr-notifications-module
8f205ad feat(patient): hydrate filters from ?search query param on page load
b638f8d feat(notifications): redesign popover card and use structured toast
06b3dce feat(notifications): structured content descriptors with deep-link routes
0aa2ccb docs(agents): document notifications metadata contract and migration 29
9c9cb2a feat(notifications): render rich messages from notification metadata
aee09d3 feat(notifications): consume denormalized metadata and drop profiles join
ff929a0 docs(agents): add system overview and notifications recipe
4d4ed1b refactor(notifications): consume registry and fix mark-as-read cache key
0305994 feat(notifications): add centralized registry and extend domain types
```

#### Dependencias

- Requiere las migraciones del PR del repo `supabase` (26 → 30) **aplicadas
  antes** de desplegar este frontend, o las notificaciones nuevas no se
  insertarán correctamente.
